### PR TITLE
Updated team and acknowledgements sections

### DIFF
--- a/src/website/content/css/style.css
+++ b/src/website/content/css/style.css
@@ -27,6 +27,10 @@
   margin: .8em 0;
 }
 
+.section.team .container p {
+  margin: 0;
+}
+
 .content .hljs {
   background: transparent
 }

--- a/src/website/data/acknowledgements.yml
+++ b/src/website/data/acknowledgements.yml
@@ -4,6 +4,5 @@ sponsors:
   - name: LetzDoIt
     url: http://www.letzdoitapp.com
 others:
-  - name: Luciano Mammino
-    url: https://loige.co
-    reason: Website design & automation
+  - name: The amazing Fastify community
+    url: https://github.com/fastify/fastify/graphs/contributors

--- a/src/website/data/team.yml
+++ b/src/website/data/team.yml
@@ -1,12 +1,53 @@
-- name: Matteo Collina
-  picture: ""
-  links:
-    github: https://github.com/mcollina
-    npm: https://www.npmjs.com/~matteo.collina
-    twitter: https://twitter.com/matteocollina
-- name: Tomas Della Vedova
-  picture: ""
-  links:
-    github: https://github.com/delvedor
-    npm: https://www.npmjs.com/~delvedor
-    twitter: https://twitter.com/delvedor
+- name: Lead Maintainers
+  people:
+  - name: Matteo Collina
+    picture: "https://avatars1.githubusercontent.com/u/52195?v=4&s=460"
+    links:
+      github: https://github.com/mcollina
+      npm: https://www.npmjs.com/~matteo.collina
+      twitter: https://twitter.com/matteocollina
+  - name: Tomas Della Vedova
+    picture: "https://avatars0.githubusercontent.com/u/4865608?v=4&s=460"
+    links:
+      github: https://github.com/delvedor
+      npm: https://www.npmjs.com/~delvedor
+      twitter: https://twitter.com/delvedor
+
+- name: Collaborators
+  people:
+  - name: Çağatay Çalı
+    picture: "https://avatars1.githubusercontent.com/u/9213230?v=4&s=460"
+    links:
+      github: https://github.com/cagataycali
+      npm: https://www.npmjs.com/~cagataycali
+      twitter: https://twitter.com/cagataycali
+  - name: Dustin Deus
+    picture: "https://avatars3.githubusercontent.com/u/1764424?v=4&s=460"
+    links:
+      github: https://github.com/StarpTech
+      npm: https://www.npmjs.com/~starptech
+      twitter: https://twitter.com/dustindeus
+  - name: Evan Shortiss
+    picture: "https://avatars3.githubusercontent.com/u/1303687?v=4&s=400"
+    links:
+      github: https://github.com/evanshortiss
+      npm: https://www.npmjs.com/~evanshortiss
+      twitter: https://twitter.com/evanshortiss
+  - name: James Sumners
+    picture: "https://avatars0.githubusercontent.com/u/321201?v=4&s=460"
+    links:
+      github: https://github.com/jsumners
+      npm: https://www.npmjs.com/~jsumners
+      twitter: https://twitter.com/jsumners79
+  - name: Luciano Mammino
+    picture: "https://avatars3.githubusercontent.com/u/205629?v=4&s=460"
+    links:
+      github: https://github.com/lmammino
+      npm: https://www.npmjs.com/~lmammino
+      twitter: https://twitter.com/loige
+  - name: Tommaso Allevi
+    picture: "https://avatars0.githubusercontent.com/u/1054125?v=4&s=460"
+    links:
+      github: https://github.com/allevo
+      npm: https://www.npmjs.com/~allevo
+      twitter: https://twitter.com/allevitommaso

--- a/src/website/layouts/home.html
+++ b/src/website/layouts/home.html
@@ -143,23 +143,37 @@ fastify.listen(3000, err => {
   </div>
 </section>
 
-<section class="section alternate">
-  <div class="container content">
-    <h1 class="title">The team</h1>
-    <div class="columns">
-      {% for member in data.team %}
-        <div class="column content">
-          <h2>{{ member.name }}</h2>
-          <ul>
-            {% for label, link in member.links %}
-              <li>
-                <a href="{{ link }}" target="_blank">{{ label }}</a>
-              </li>
-            {% endfor %}
-          </ul>
-        </div>
-      {% endfor %}
+<section class="section alternate team">
+  <div class="container">
+    <div class="content">
+      <h1 class="title">The team</h1>
     </div>
+    {% for section in data.team %}
+      <div class="content">
+        <h2>{{ section.name }}</h2>
+      </div>
+      <div class="columns is-multiline">
+        {% for member in section.people %}
+          <div class="column is-one-third">
+            <div class="media">
+              <div class="media-left">
+                <figure class="image is-48x48">
+                  <img src="{{ member.picture }}" alt="{{ member.name }}'s profile picture">
+                </figure>
+              </div>
+              <div class="media-content">
+                <p class="title is-5">{{ member.name }}</p>
+                <p class="subtitle is-6">
+                  {% for label, link in member.links %}
+                    <a href="{{ link }}" target="_blank">{{ label }}</a>
+                  {% endfor %}
+                </p>
+              </div>
+            </div>
+          </div>
+        {% endfor %}
+      </div>
+    {% endfor %}
   </div>
 </section>
 

--- a/src/website/layouts/home.html
+++ b/src/website/layouts/home.html
@@ -153,7 +153,7 @@ fastify.listen(3000, err => {
         <h2>{{ section.name }}</h2>
       </div>
       <div class="columns is-multiline">
-        {% for member in section.people %}
+        {% for member in section.people | sort(false, false, 'name') %}
           <div class="column is-one-third">
             <div class="media">
               <div class="media-left">

--- a/src/website/layouts/home.html
+++ b/src/website/layouts/home.html
@@ -147,6 +147,7 @@ fastify.listen(3000, err => {
   <div class="container">
     <div class="content">
       <h1 class="title">The team</h1>
+      <p>In alphabetical order</p>
     </div>
     {% for section in data.team %}
       <div class="content">


### PR DESCRIPTION
This is a preview of the new team section on the website as implemented by this PR:

<img width="943" alt="screen shot 2017-10-11 at 23 50 33" src="https://user-images.githubusercontent.com/205629/31471151-3996f540-aedf-11e7-9e94-2528918b5f8e.png">

Notice that also the acknowledgements section has been slightly  changed and now there's an explicit mention of the full community (with a link to the list of contributors on GitHub)

Closes #33 