### PR TITLE
Use node executable explicitely in npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "build:cleanup": "rimraf build-temp",
     "build:create-temp-folder": "mkdirp build-temp",
-    "build:get-releases": "src/scripts/downloadReleases.js fastify/fastify build-temp/releases v0.11.0",
-    "build:process-releases": "src/scripts/processReleases.js build-temp/releases src/website",
-    "build:website": "src/scripts/buildWebsite.js",
+    "build:get-releases": "node src/scripts/downloadReleases.js fastify/fastify build-temp/releases v0.11.0",
+    "build:process-releases": "node src/scripts/processReleases.js build-temp/releases src/website",
+    "build:website": "node src/scripts/buildWebsite.js",
     "build": "npm run build:cleanup && npm run build:create-temp-folder && npm run build:get-releases && npm run build:process-releases && npm run build:website",
     "deploy": "gh-pages -d build --dotfiles",
     "test:lint": "eslint src --ignore-pattern 'src/website/content/'",


### PR DESCRIPTION
As pointed out by @brunoscopelliti in a private conversation, this small change will make the npm scripts compatible also with windows.