### PR TITLE
Fix example on the home page

### DIFF
--- a/src/website/layouts/home.html
+++ b/src/website/layouts/home.html
@@ -162,11 +162,11 @@ fastify.route({
           hello: { type: 'string' }
         }
       }
-    },
-    // this function is executed for every request before the handler is executed
-    beforeHandler: async (request, reply) => {
-      // E.g. check authentication
     }
+  },
+  // this function is executed for every request before the handler is executed
+  beforeHandler: async (request, reply) => {
+    // E.g. check authentication
   },
   handler: async (request, reply) => {
     return { hello: 'world' }


### PR DESCRIPTION
The `beforeHandler` route option was accidentally inside the `schema` object.