### PR TITLE
fix(home.html): generalize developer gender

### DIFF
--- a/src/website/layouts/home.html
+++ b/src/website/layouts/home.html
@@ -204,7 +204,7 @@ start()</code></pre>
           <li><strong>Extendible:</strong> Fastify is fully extensible via its hooks, plugins and decorators.</li>
           <li><strong>Schema based:</strong> even if it is not mandatory we recommend to use <a href="http://json-schema.org/" target="_blank">JSON Schema</a> to validate your routes and serialize your outputs, internally Fastify compiles the schema in an highly performant function.</li>
           <li><strong>Logging:</strong> logs are extremely important but are costly; we chose the best logger to almost remove this cost, <a href="https://github.com/pinojs/pino" target="_blank">Pino</a>!</li>
-          <li><strong>Developer friendly:</strong> the framework is built to be very expressive and help the developer in his daily use, without sacrificing performance and security.</li>
+          <li><strong>Developer friendly:</strong> the framework is built to be very expressive and to help developers in their daily use, without sacrificing performance and security.</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Noticed a (presumably unintentional) slight to developers of the non-male variety. This change would make it clear that the developers of Fastify are not of the opinion that software development is exclusively the domain of men.