### PR TITLE
Fix typo in organisations.md

### DIFF
--- a/src/website/content/organisations.md
+++ b/src/website/content/organisations.md
@@ -1,5 +1,5 @@
 ---
-title: Orgaisations using fastify
+title: Organisations using Fastify
 layout: organisations.html
 path: /organisations
 github_url: https://github.com/fastify/website/blob/master/src/website/layouts/organisations.html


### PR DESCRIPTION
`Orgaisations using fastify` -> `Organisations using Fastify`