### PR TITLE
Adjust src/website/layouts/docs_page.html column classes

### DIFF
--- a/src/website/layouts/docs_page.html
+++ b/src/website/layouts/docs_page.html
@@ -15,7 +15,7 @@
   <section class="section">
     <div class="columns">
 
-      <div class="column is-desktop is-one-quarter-desktop" data-sticky-container>
+      <div class="column is-one-quarter" data-sticky-container>
         <aside class="menu sticky">
           <p class="menu-label">
             Table of contents
@@ -50,7 +50,7 @@
         </aside>
       </div>
 
-      <div class="column is-three-quarters-desktop">
+      <div class="column is-three-quarters">
         <nav class="breadcrumb">
           <ul>
             <li><a href="/" style="padding-left: 0">Fastify</a></li>

--- a/src/website/layouts/docs_page.html
+++ b/src/website/layouts/docs_page.html
@@ -15,7 +15,7 @@
   <section class="section">
     <div class="columns">
 
-      <div class="column is-3 is-hidden-mobile" data-sticky-container>
+      <div class="column is-desktop is-one-quarter-desktop" data-sticky-container>
         <aside class="menu sticky">
           <p class="menu-label">
             Table of contents
@@ -50,7 +50,7 @@
         </aside>
       </div>
 
-      <div class="column">
+      <div class="column is-three-quarters-desktop">
         <nav class="breadcrumb">
           <ul>
             <li><a href="/" style="padding-left: 0">Fastify</a></li>


### PR DESCRIPTION
Hi! Currently in `desktop` view the doc page main column's content overflows the screen width (if the content text is long enough and the screen is not wide enough). 

See the [Typescript and types support](https://www.fastify.io/docs/latest/TypeScript/) page with 770-1400 px wide screen for example. 

The PR changes `bluma` classes to control the max width of the block.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

