### PR TITLE
Use logger in demo code

### DIFF
--- a/src/website/layouts/home.html
+++ b/src/website/layouts/home.html
@@ -80,7 +80,7 @@
             </div>
           </div>
           <pre class="no-async swappable-async-await-code"><code class="javascript">// Require the framework and instantiate it
-const fastify = require('fastify')()
+const fastify = require('fastify')({ logger: true })
 
 // Declare a route
 fastify.get('/', (request, reply) => {
@@ -96,7 +96,7 @@ fastify.listen(3000, (err) => {
   fastify.log.info(`server listening on ${fastify.server.address().port}`)
 })</code></pre>
           <pre class="async swappable-async-await-code"><code class="javascript">// Require the framework and instantiate it
-const fastify = require('fastify')()
+const fastify = require('fastify')({ logger: true })
 
 // Declare a route
 fastify.get('/', async (request, reply) => {
@@ -136,7 +136,7 @@ start()
               <label for="async-await-swap-2"></label>
             </div>
           </div>
-          <pre class="no-async swappable-async-await-code"><code class="javascript">const fastify = require('fastify')()
+          <pre class="no-async swappable-async-await-code"><code class="javascript">const fastify = require('fastify')({ logger: true })
 
 fastify.route({
   method: 'GET',
@@ -173,7 +173,7 @@ fastify.listen(3000, (err) => {
   }
   fastify.log.info(`server listening on ${fastify.server.address().port}`)
 })</code></pre>
-          <pre class="async swappable-async-await-code"><code class="javascript">const fastify = require('fastify')()
+          <pre class="async swappable-async-await-code"><code class="javascript">const fastify = require('fastify')({ logger: true })
 
 fastify.route({
   method: 'GET',


### PR DESCRIPTION
If a new user copies the current code on the homepage, they may be surprised to see no logs in their console when making a request. While including the `logger` option makes the example more bloated, I think having the logs in and running is closer to a real world example. It should also reduce some confusion.

An alternative here would be to remove all of the log lines but I don't think that is valuable.