### PR TITLE
Number of plugins on button "Explore plugin" are incorrect.

### DIFF
--- a/src/website/layouts/home.html
+++ b/src/website/layouts/home.html
@@ -262,7 +262,7 @@ start()</code></pre>
         </p>
         <div class="block">
           <!-- The number of plugins are by mistakenly returned 2 although there are 36 core and 72 community plugins  -->
-          <a class="button is-primary is-large is-flex-mobile" href="/ecosystem">Explore {{ data.ecosystem.plugins | length }} plugins</a>
+          <a class="button is-primary is-large is-flex-mobile" href="/ecosystem">Explore {{ data.ecosystem.plugins.corePlugins | length + data.ecosystem.plugins.communityPlugins | length }} plugins</a>
         </div>
       </div>
     </div>

--- a/src/website/layouts/home.html
+++ b/src/website/layouts/home.html
@@ -261,6 +261,7 @@ start()</code></pre>
           Can't you find the plugin you are looking for? No problem, <a href="/docs/master/Plugins">it's very easy to write one</a>!
         </p>
         <div class="block">
+          <!-- The number of plugins are by mistakenly returned 2 although there are 36 core and 72 community plugins  -->
           <a class="button is-primary is-large is-flex-mobile" href="/ecosystem">Explore {{ data.ecosystem.plugins | length }} plugins</a>
         </div>
       </div>


### PR DESCRIPTION
The number of plugins must be 36 core + 72 community plugins i.e 108 on the Explore plugin button on the homepage but it shows 2 plugins. I couldn't find the source of the numbers calculation but I tried to point it out