### PR TITLE
Fixed the counting of number of plugins

### DIFF
--- a/src/website/layouts/home.html
+++ b/src/website/layouts/home.html
@@ -1,14 +1,36 @@
-{% extends "default.html" %}
-
-{% block content %}
-<div class="hero" style="background-image: url(/{{ hashes['images/bg-pattern-dark.png'] }})">
+{% extends "default.html" %} {% block content %}
+<div
+  class="hero"
+  style="background-image: url(/{{ hashes['images/bg-pattern-dark.png'] }})"
+>
   <div class="hero-body">
     <div class="container">
-      <h1 class="title"><img class="logo" src="/{{ hashes['images/fastify-logo-inverted.png'] }}" alt="Fastify"/></h1>
+      <h1 class="title">
+        <img
+          class="logo"
+          src="/{{ hashes['images/fastify-logo-inverted.png'] }}"
+          alt="Fastify"
+        />
+      </h1>
       <h2 class="subtitle">Fast and low overhead web framework, for Node.js</h2>
       <div class="github-buttons">
-        <a class="github-button" href="https://github.com/fastify/fastify" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star fastify/fastify on GitHub">Star</a>
-        <a class="github-button" href="https://github.com/fastify/fastify/fork" data-icon="octicon-repo-forked" data-size="large" aria-label="Fork fastify/fastify on GitHub">Fork</a>
+        <a
+          class="github-button"
+          href="https://github.com/fastify/fastify"
+          data-icon="octicon-star"
+          data-size="large"
+          data-show-count="true"
+          aria-label="Star fastify/fastify on GitHub"
+          >Star</a
+        >
+        <a
+          class="github-button"
+          href="https://github.com/fastify/fastify/fork"
+          data-icon="octicon-repo-forked"
+          data-size="large"
+          aria-label="Fork fastify/fastify on GitHub"
+          >Fork</a
+        >
         <script async defer src="https://buttons.github.io/buttons.js"></script>
       </div>
     </div>
@@ -21,12 +43,17 @@
       <div class="column is-10">
         <h1 class="title">Why</h1>
         <p>
-          An efficient server implies a lower cost of the infrastructure, a better responsiveness under load and happy users.
-          How can you efficiently handle the resources of your server, knowing that you are serving the highest number of requests as possible, without sacrificing security validations and handy development?
+          An efficient server implies a lower cost of the infrastructure, a
+          better responsiveness under load and happy users. How can you
+          efficiently handle the resources of your server, knowing that you are
+          serving the highest number of requests as possible, without
+          sacrificing security validations and handy development?
         </p>
         <p>
-          Enter Fastify. Fastify is a web framework highly focused on providing the best developer experience with the least overhead and a powerful plugin architecture.
-          It is inspired by Hapi and Express and as far as we know, it is one of the fastest web frameworks in town.
+          Enter Fastify. Fastify is a web framework highly focused on providing
+          the best developer experience with the least overhead and a powerful
+          plugin architecture. It is inspired by Hapi and Express and as far as
+          we know, it is one of the fastest web frameworks in town.
         </p>
       </div>
     </div>
@@ -38,24 +65,35 @@
     <div class="columns is-centered">
       <div class="column is-10">
         <h1 class="title">Who is using Fastify?</h1>
-        <p>Fastify is proudly powering a large ecosystem of organisations and products out there.</p>
-        <p>Discover <a href="/organisations">more organisations using Fastify</a>. Do want your organisation to <a href="/organisations#how-to-be-featured">be featured here</a>?</p>
+        <p>
+          Fastify is proudly powering a large ecosystem of organisations and
+          products out there.
+        </p>
+        <p>
+          Discover
+          <a href="/organisations">more organisations using Fastify</a>. Do want
+          your organisation to
+          <a href="/organisations#how-to-be-featured">be featured here</a>?
+        </p>
       </div>
     </div>
     <div class="columns is-centered">
       <div class="column is-12">
         <ul class="organisations-list">
-          {% set shuffledOrganisations = data.organisations | shuffle %}
-          {% for organizationIndex in range(0, 6) %}
-            {% set organization = shuffledOrganisations[organizationIndex] %}
-            {% if organization %}
-            <li>
-              <a href="{{ organization.link }}" target="_blank" rel="nofollow">
-                <img src="/{{ hashes['images/organisations/' + organization.image] }}" alt="{{ organization.name }} is using Fastify"/>
-              </a>
-            </li>
-            {% endif %}
-          {% endfor %}
+          {% set shuffledOrganisations = data.organisations | shuffle %} {% for
+          organizationIndex in range(0, 6) %} {% set organization =
+          shuffledOrganisations[organizationIndex] %} {% if organization %}
+          <li>
+            <a href="{{ organization.link }}" target="_blank" rel="nofollow">
+              <img
+                src="/{{
+                  hashes['images/organisations/' + organization.image]
+                }}"
+                alt="{{ organization.name }} is using Fastify"
+              />
+            </a>
+          </li>
+          {% endif %} {% endfor %}
         </ul>
       </div>
     </div>
@@ -76,11 +114,20 @@
           <div class="swap-button-box">
             <label for="async-await-swap-1">async/await</label>
             <div class="toggle-checkbox">
-              <input type="checkbox" class="swappable-async-await-checkbox" id="async-await-swap-1" value="0" checked="" name="async-await-swap-1">
+              <input
+                type="checkbox"
+                class="swappable-async-await-checkbox"
+                id="async-await-swap-1"
+                value="0"
+                checked=""
+                name="async-await-swap-1"
+              />
               <label for="async-await-swap-1"></label>
             </div>
           </div>
-          <pre class="no-async swappable-async-await-code"><code class="javascript">// Require the framework and instantiate it
+          <pre
+            class="no-async swappable-async-await-code"
+          ><code class="javascript">// Require the framework and instantiate it
 const fastify = require('fastify')({ logger: true })
 
 // Declare a route
@@ -96,7 +143,9 @@ fastify.listen(3000, (err) => {
   }
   fastify.log.info(`server listening on ${fastify.server.address().port}`)
 })</code></pre>
-          <pre class="async swappable-async-await-code"><code class="javascript">// Require the framework and instantiate it
+          <pre
+            class="async swappable-async-await-code"
+          ><code class="javascript">// Require the framework and instantiate it
 const fastify = require('fastify')({ logger: true })
 
 // Declare a route
@@ -127,17 +176,30 @@ start()
         <h2>Request/Response validation and hooks</h2>
 
         <p>Of course, Fastify can do much more than this.</p>
-        <p>For example, you can easily provide input and output validation using JSON Schema and perform specific operation before the handler is executed:</p>
+        <p>
+          For example, you can easily provide input and output validation using
+          JSON Schema and perform specific operation before the handler is
+          executed:
+        </p>
 
         <div class="swappable-async-await">
           <div class="swap-button-box">
             <label for="async-await-swap-2">async/await</label>
             <div class="toggle-checkbox">
-              <input type="checkbox" class="swappable-async-await-checkbox" id="async-await-swap-2" value="0" checked="" name="async-await-swap-2">
+              <input
+                type="checkbox"
+                class="swappable-async-await-checkbox"
+                id="async-await-swap-2"
+                value="0"
+                checked=""
+                name="async-await-swap-2"
+              />
               <label for="async-await-swap-2"></label>
             </div>
           </div>
-          <pre class="no-async swappable-async-await-code"><code class="javascript">const fastify = require('fastify')({ logger: true })
+          <pre
+            class="no-async swappable-async-await-code"
+          ><code class="javascript">const fastify = require('fastify')({ logger: true })
 
 fastify.route({
   method: 'GET',
@@ -174,7 +236,9 @@ fastify.listen(3000, (err) => {
   }
   fastify.log.info(`server listening on ${fastify.server.address().port}`)
 })</code></pre>
-          <pre class="async swappable-async-await-code"><code class="javascript">const fastify = require('fastify')({ logger: true })
+          <pre
+            class="async swappable-async-await-code"
+          ><code class="javascript">const fastify = require('fastify')({ logger: true })
 
 fastify.route({
   method: 'GET',
@@ -215,7 +279,10 @@ const start = async () => {
 start()</code></pre>
         </div>
 
-        <p>Visit the <a href="/docs">Documentation</a> to learn more about all the features that Fastify has to offer.</p>
+        <p>
+          Visit the <a href="/docs">Documentation</a> to learn more about all
+          the features that Fastify has to offer.
+        </p>
       </div>
     </div>
   </div>
@@ -227,15 +294,48 @@ start()</code></pre>
       <div class="column is-10">
         <h1 class="title">Core features</h1>
 
-        <p>These are the main features and principles on which fastify has been built:</p>
+        <p>
+          These are the main features and principles on which fastify has been
+          built:
+        </p>
 
         <ul>
-          <li><strong>Highly performant:</strong> as far as we know, Fastify is one of the fastest web frameworks in town, depending on the code complexity we can serve up to 30 thousand requests per second.</li>
-          <li><strong>Extendible:</strong> Fastify is fully extensible via its hooks, plugins and decorators.</li>
-          <li><strong>Schema based:</strong> even if it is not mandatory we recommend to use <a href="http://json-schema.org/" target="_blank">JSON Schema</a> to validate your routes and serialize your outputs, internally Fastify compiles the schema in an highly performant function.</li>
-          <li><strong>Logging:</strong> logs are extremely important but are costly; we chose the best logger to almost remove this cost, <a href="https://github.com/pinojs/pino" target="_blank">Pino</a>!</li>
-          <li><strong>Developer friendly:</strong> the framework is built to be very expressive and to help developers in their daily use, without sacrificing performance and security.</li>
-          <li><strong>TypeScript ready:</strong> we work hard to maintain a <a href="https://www.typescriptlang.org/" aria-label="Link to TypeScript website">TypeScript</a> type declaration file so we can support the growing TypeScript community.</li>
+          <li>
+            <strong>Highly performant:</strong> as far as we know, Fastify is
+            one of the fastest web frameworks in town, depending on the code
+            complexity we can serve up to 30 thousand requests per second.
+          </li>
+          <li>
+            <strong>Extendible:</strong> Fastify is fully extensible via its
+            hooks, plugins and decorators.
+          </li>
+          <li>
+            <strong>Schema based:</strong> even if it is not mandatory we
+            recommend to use
+            <a href="http://json-schema.org/" target="_blank">JSON Schema</a> to
+            validate your routes and serialize your outputs, internally Fastify
+            compiles the schema in an highly performant function.
+          </li>
+          <li>
+            <strong>Logging:</strong> logs are extremely important but are
+            costly; we chose the best logger to almost remove this cost,
+            <a href="https://github.com/pinojs/pino" target="_blank">Pino</a>!
+          </li>
+          <li>
+            <strong>Developer friendly:</strong> the framework is built to be
+            very expressive and to help developers in their daily use, without
+            sacrificing performance and security.
+          </li>
+          <li>
+            <strong>TypeScript ready:</strong> we work hard to maintain a
+            <a
+              href="https://www.typescriptlang.org/"
+              aria-label="Link to TypeScript website"
+              >TypeScript</a
+            >
+            type declaration file so we can support the growing TypeScript
+            community.
+          </li>
         </ul>
       </div>
     </div>
@@ -244,24 +344,41 @@ start()</code></pre>
 
 <section class="section alternate">
   <div class="container content">
-
     <div class="columns">
       <div class="column is-6">
         <h1 class="title">A fast web framework</h1>
-        <p>Leveraging our experience with Node.js performance, Fastify has been built from the ground up to be <strong>as fast as possible</strong>. Have  a look at our <a href="/benchmarks">benchmarks section</a> to compare fastify performance to other common web frameworks.</p>
+        <p>
+          Leveraging our experience with Node.js performance, Fastify has been
+          built from the ground up to be <strong>as fast as possible</strong>.
+          Have a look at our <a href="/benchmarks">benchmarks section</a> to
+          compare fastify performance to other common web frameworks.
+        </p>
         <div class="block">
-          <p><a class="button is-primary is-large is-flex-mobile" href="/benchmarks">Checkout our benchmarks</a></p>
+          <p>
+            <a
+              class="button is-primary is-large is-flex-mobile"
+              href="/benchmarks"
+              >Checkout our benchmarks</a
+            >
+          </p>
         </div>
       </div>
       <div class="column is-6">
         <h1 class="title">Ecosystem</h1>
         <p>
-          Fastify has an ever-growing ecosystem of plugins. Probably there is already a plugin for your favourite database or template language.
-          Have a look at the <a href="/ecosystem">Ecosystem page</a> to navigate through the currently available plugins.
-          Can't you find the plugin you are looking for? No problem, <a href="/docs/master/Plugins">it's very easy to write one</a>!
+          Fastify has an ever-growing ecosystem of plugins. Probably there is
+          already a plugin for your favourite database or template language.
+          Have a look at the <a href="/ecosystem">Ecosystem page</a> to navigate
+          through the currently available plugins. Can't you find the plugin you
+          are looking for? No problem,
+          <a href="/docs/master/Plugins">it's very easy to write one</a>!
         </p>
         <div class="block">
-          <a class="button is-primary is-large is-flex-mobile" href="/ecosystem">Explore {{ data.ecosystem.plugins | length }} plugins</a>
+          <a class="button is-primary is-large is-flex-mobile" href="/ecosystem"
+            >Explore
+            {{ data.ecosystem.plugins.corePlugins | length + data.ecosystem.plugins.communityPlugins | length }}
+            plugins</a
+          >
         </div>
       </div>
     </div>
@@ -272,63 +389,67 @@ start()</code></pre>
   <div class="container">
     <div class="columns is-centered">
       <div class="column is-10">
-
         <div class="content">
           <h1 class="title">The team</h1>
           <p>In alphabetical order</p>
         </div>
         {% for section in data.team %}
-          <div class="content">
-            <h2>{{ section.name }}</h2>
-          </div>
-          <div class="columns is-multiline">
-            {% for member in section.people | sort(false, false, 'sortname') %}
-              <div class="column is-one-third">
-                <div class="media">
-                  <div class="media-left">
-                    <figure class="image is-48x48">
-                      <img src="{{ member.picture }}" alt="{{ member.name }}'s profile picture">
-                    </figure>
-                  </div>
-                  <div class="media-content">
-                    <p class="title is-5">{{ member.name }}</p>
-                    <p class="subtitle is-6">
-                      {% for label, link in member.links %}
-                        <a href="{{ link }}" target="_blank">{{ label }}</a>
-                      {% endfor %}
-                    </p>
-                  </div>
-                </div>
+        <div class="content">
+          <h2>{{ section.name }}</h2>
+        </div>
+        <div class="columns is-multiline">
+          {% for member in section.people | sort(false, false, 'sortname') %}
+          <div class="column is-one-third">
+            <div class="media">
+              <div class="media-left">
+                <figure class="image is-48x48">
+                  <img
+                    src="{{ member.picture }}"
+                    alt="{{ member.name }}'s profile picture"
+                  />
+                </figure>
               </div>
-            {% endfor %}
+              <div class="media-content">
+                <p class="title is-5">{{ member.name }}</p>
+                <p class="subtitle is-6">
+                  {% for label, link in member.links %}
+                  <a href="{{ link }}" target="_blank">{{ label }}</a>
+                  {% endfor %}
+                </p>
+              </div>
+            </div>
           </div>
+          {% endfor %}
+        </div>
         {% endfor %}
 
         <div class="content">
-          <hr/>
+          <hr />
           <h1 class="title">Acknowledgments</h1>
           <p>This project is kindly <strong>sponsored by</strong>:</p>
           <ul>
             {% for link in data.acknowledgements.sponsors %}
-              <li>
-                <a href="{{ link.url }}" target="_blank">{{ link.name }}</a>
-              </li>
+            <li>
+              <a href="{{ link.url }}" target="_blank">{{ link.name }}</a>
+            </li>
             {% endfor %}
           </ul>
           <p>Past Sponsors:</p>
           <ul>
             {% for link in data.acknowledgements.past_sponsors %}
-              <li>
-                <a href="{{ link.url }}" target="_blank">{{ link.name }}</a>{% if link.reason %} ({{ link.reason }}){% endif %}
-              </li>
+            <li>
+              <a href="{{ link.url }}" target="_blank">{{ link.name }}</a
+              >{% if link.reason %} ({{ link.reason }}){% endif %}
+            </li>
             {% endfor %}
           </ul>
           <p>Also thanks to:</p>
           <ul>
             {% for link in data.acknowledgements.others %}
-              <li>
-                <a href="{{ link.url }}" target="_blank">{{ link.name }}</a>{% if link.reason %} ({{ link.reason }}){% endif %}
-              </li>
+            <li>
+              <a href="{{ link.url }}" target="_blank">{{ link.name }}</a
+              >{% if link.reason %} ({{ link.reason }}){% endif %}
+            </li>
             {% endfor %}
           </ul>
         </div>
@@ -336,48 +457,46 @@ start()</code></pre>
     </div>
   </div>
 </section>
-{% endblock %}
-
-
-{% block extraScripts %}
+{% endblock %} {% block extraScripts %}
 <script type="text/javascript">
   (function() {
-    var state = { preferAsync: true }
+    var state = { preferAsync: true };
     function getAsyncToggles() {
-      return document.getElementsByClassName('swappable-async-await-checkbox')
+      return document.getElementsByClassName("swappable-async-await-checkbox");
     }
 
     function getCodeBlocks() {
-      return document.getElementsByClassName('swappable-async-await-code')
+      return document.getElementsByClassName("swappable-async-await-code");
     }
 
     function initAsyncToggle() {
-      var toggles = getAsyncToggles()
-      for (var i=0; i < toggles.length; i++) {
-        toggles.item(i).addEventListener('change', function (e) {
-          state.preferAsync = e.target.checked
-          updateView()
-        })
+      var toggles = getAsyncToggles();
+      for (var i = 0; i < toggles.length; i++) {
+        toggles.item(i).addEventListener("change", function(e) {
+          state.preferAsync = e.target.checked;
+          updateView();
+        });
       }
     }
 
     function updateView() {
-      var toggles = getAsyncToggles()
-      for (var i=0; i < toggles.length; i++) {
-        toggles.item(i).checked = state.preferAsync
+      var toggles = getAsyncToggles();
+      for (var i = 0; i < toggles.length; i++) {
+        toggles.item(i).checked = state.preferAsync;
       }
 
-      var codeBlocks = getCodeBlocks()
-      for (var i=0; i < codeBlocks.length; i++) {
-        var block = codeBlocks.item(i)
-        var show = (block.className.indexOf('async') === 0 && state.preferAsync) ||
-          (block.className.indexOf('no-async') === 0 && !state.preferAsync)
-        block.style.display = show ? 'block' : 'none'
+      var codeBlocks = getCodeBlocks();
+      for (var i = 0; i < codeBlocks.length; i++) {
+        var block = codeBlocks.item(i);
+        var show =
+          (block.className.indexOf("async") === 0 && state.preferAsync) ||
+          (block.className.indexOf("no-async") === 0 && !state.preferAsync);
+        block.style.display = show ? "block" : "none";
       }
     }
 
-    initAsyncToggle()
-    updateView()
-  })()
+    initAsyncToggle();
+    updateView();
+  })();
 </script>
 {% endblock %}

--- a/src/website/layouts/home.html
+++ b/src/website/layouts/home.html
@@ -1,133 +1,102 @@
 {% extends "default.html" %} {% block content %}
-<div
-  class="hero"
-  style="background-image: url(/{{ hashes['images/bg-pattern-dark.png'] }})"
->
-  <div class="hero-body">
-    <div class="container">
-      <h1 class="title">
-        <img
-          class="logo"
-          src="/{{ hashes['images/fastify-logo-inverted.png'] }}"
-          alt="Fastify"
-        />
-      </h1>
-      <h2 class="subtitle">Fast and low overhead web framework, for Node.js</h2>
-      <div class="github-buttons">
-        <a
-          class="github-button"
-          href="https://github.com/fastify/fastify"
-          data-icon="octicon-star"
-          data-size="large"
-          data-show-count="true"
-          aria-label="Star fastify/fastify on GitHub"
-          >Star</a
-        >
-        <a
-          class="github-button"
-          href="https://github.com/fastify/fastify/fork"
-          data-icon="octicon-repo-forked"
-          data-size="large"
-          aria-label="Fork fastify/fastify on GitHub"
-          >Fork</a
-        >
-        <script async defer src="https://buttons.github.io/buttons.js"></script>
-      </div>
+<div class="hero" style="background-image: url(/{{ hashes['images/bg-pattern-dark.png'] }})">
+    <div class="hero-body">
+        <div class="container">
+            <h1 class="title">
+                <img class="logo" src="/{{ hashes['images/fastify-logo-inverted.png'] }}" alt="Fastify" />
+            </h1>
+            <h2 class="subtitle">Fast and low overhead web framework, for Node.js</h2>
+            <div class="github-buttons">
+                <a class="github-button" href="https://github.com/fastify/fastify" data-icon="octicon-star"
+                    data-size="large" data-show-count="true" aria-label="Star fastify/fastify on GitHub">Star</a>
+                <a class="github-button" href="https://github.com/fastify/fastify/fork" data-icon="octicon-repo-forked"
+                    data-size="large" aria-label="Fork fastify/fastify on GitHub">Fork</a>
+                <script async defer src="https://buttons.github.io/buttons.js"></script>
+            </div>
+        </div>
     </div>
-  </div>
 </div>
 
 <section class="section">
-  <div class="container content">
-    <div class="columns is-centered">
-      <div class="column is-10">
-        <h1 class="title">Why</h1>
-        <p>
-          An efficient server implies a lower cost of the infrastructure, a
-          better responsiveness under load and happy users. How can you
-          efficiently handle the resources of your server, knowing that you are
-          serving the highest number of requests as possible, without
-          sacrificing security validations and handy development?
-        </p>
-        <p>
-          Enter Fastify. Fastify is a web framework highly focused on providing
-          the best developer experience with the least overhead and a powerful
-          plugin architecture. It is inspired by Hapi and Express and as far as
-          we know, it is one of the fastest web frameworks in town.
-        </p>
-      </div>
+    <div class="container content">
+        <div class="columns is-centered">
+            <div class="column is-10">
+                <h1 class="title">Why</h1>
+                <p>
+                    An efficient server implies a lower cost of the infrastructure, a
+                    better responsiveness under load and happy users. How can you
+                    efficiently handle the resources of your server, knowing that you are
+                    serving the highest number of requests as possible, without
+                    sacrificing security validations and handy development?
+                </p>
+                <p>
+                    Enter Fastify. Fastify is a web framework highly focused on providing
+                    the best developer experience with the least overhead and a powerful
+                    plugin architecture. It is inspired by Hapi and Express and as far as
+                    we know, it is one of the fastest web frameworks in town.
+                </p>
+            </div>
+        </div>
     </div>
-  </div>
 </section>
 
 <section class="section">
-  <div class="container content">
-    <div class="columns is-centered">
-      <div class="column is-10">
-        <h1 class="title">Who is using Fastify?</h1>
-        <p>
-          Fastify is proudly powering a large ecosystem of organisations and
-          products out there.
-        </p>
-        <p>
-          Discover
-          <a href="/organisations">more organisations using Fastify</a>. Do want
-          your organisation to
-          <a href="/organisations#how-to-be-featured">be featured here</a>?
-        </p>
-      </div>
-    </div>
-    <div class="columns is-centered">
-      <div class="column is-12">
-        <ul class="organisations-list">
-          {% set shuffledOrganisations = data.organisations | shuffle %} {% for
+    <div class="container content">
+        <div class="columns is-centered">
+            <div class="column is-10">
+                <h1 class="title">Who is using Fastify?</h1>
+                <p>
+                    Fastify is proudly powering a large ecosystem of organisations and
+                    products out there.
+                </p>
+                <p>
+                    Discover
+                    <a href="/organisations">more organisations using Fastify</a>. Do want
+                    your organisation to
+                    <a href="/organisations#how-to-be-featured">be featured here</a>?
+                </p>
+            </div>
+        </div>
+        <div class="columns is-centered">
+            <div class="column is-12">
+                <ul class="organisations-list">
+                    {% set shuffledOrganisations = data.organisations | shuffle %} {% for
           organizationIndex in range(0, 6) %} {% set organization =
           shuffledOrganisations[organizationIndex] %} {% if organization %}
-          <li>
-            <a href="{{ organization.link }}" target="_blank" rel="nofollow">
-              <img
-                src="/{{
+                    <li>
+                        <a href="{{ organization.link }}" target="_blank" rel="nofollow">
+                            <img src="/{{
                   hashes['images/organisations/' + organization.image]
-                }}"
-                alt="{{ organization.name }} is using Fastify"
-              />
-            </a>
-          </li>
-          {% endif %} {% endfor %}
-        </ul>
-      </div>
+                }}" alt="{{ organization.name }} is using Fastify" />
+                        </a>
+                    </li>
+                    {% endif %} {% endfor %}
+                </ul>
+            </div>
+        </div>
     </div>
-  </div>
 </section>
 
 <section class="section alternate">
-  <div class="container content">
-    <div class="columns is-centered">
-      <div class="column is-10">
-        <h1 class="title">Quick start</h1>
-        <p>Get fastify with NPM:</p>
-        <pre><code class="shell">npm install fastify</code></pre>
+    <div class="container content">
+        <div class="columns is-centered">
+            <div class="column is-10">
+                <h1 class="title">Quick start</h1>
+                <p>Get fastify with NPM:</p>
+                <pre><code class="shell">npm install fastify</code></pre>
 
-        <p>Then create <code>server.js</code> and add the following content:</p>
+                <p>Then create <code>server.js</code> and add the following content:</p>
 
-        <div class="swappable-async-await">
-          <div class="swap-button-box">
-            <label for="async-await-swap-1">async/await</label>
-            <div class="toggle-checkbox">
-              <input
-                type="checkbox"
-                class="swappable-async-await-checkbox"
-                id="async-await-swap-1"
-                value="0"
-                checked=""
-                name="async-await-swap-1"
-              />
-              <label for="async-await-swap-1"></label>
-            </div>
-          </div>
-          <pre
-            class="no-async swappable-async-await-code"
-          ><code class="javascript">// Require the framework and instantiate it
+                <div class="swappable-async-await">
+                    <div class="swap-button-box">
+                        <label for="async-await-swap-1">async/await</label>
+                        <div class="toggle-checkbox">
+                            <input type="checkbox" class="swappable-async-await-checkbox" id="async-await-swap-1"
+                                value="0" checked="" name="async-await-swap-1" />
+                            <label for="async-await-swap-1"></label>
+                        </div>
+                    </div>
+                    <pre class="no-async swappable-async-await-code"><code class="javascript">// Require the framework and instantiate it
 const fastify = require('fastify')({ logger: true })
 
 // Declare a route
@@ -143,9 +112,7 @@ fastify.listen(3000, (err) => {
   }
   fastify.log.info(`server listening on ${fastify.server.address().port}`)
 })</code></pre>
-          <pre
-            class="async swappable-async-await-code"
-          ><code class="javascript">// Require the framework and instantiate it
+                    <pre class="async swappable-async-await-code"><code class="javascript">// Require the framework and instantiate it
 const fastify = require('fastify')({ logger: true })
 
 // Declare a route
@@ -165,41 +132,33 @@ const start = async () => {
 }
 start()
 </code></pre>
-        </div>
+                </div>
 
-        <p>Finally, launch the server with:</p>
-        <pre><code class="shell">node server</code></pre>
+                <p>Finally, launch the server with:</p>
+                <pre><code class="shell">node server</code></pre>
 
-        <p>and you can test it with:</p>
-        <pre><code class="shell">curl http://localhost:3000</code></pre>
+                <p>and you can test it with:</p>
+                <pre><code class="shell">curl http://localhost:3000</code></pre>
 
-        <h2>Request/Response validation and hooks</h2>
+                <h2>Request/Response validation and hooks</h2>
 
-        <p>Of course, Fastify can do much more than this.</p>
-        <p>
-          For example, you can easily provide input and output validation using
-          JSON Schema and perform specific operation before the handler is
-          executed:
-        </p>
+                <p>Of course, Fastify can do much more than this.</p>
+                <p>
+                    For example, you can easily provide input and output validation using
+                    JSON Schema and perform specific operation before the handler is
+                    executed:
+                </p>
 
-        <div class="swappable-async-await">
-          <div class="swap-button-box">
-            <label for="async-await-swap-2">async/await</label>
-            <div class="toggle-checkbox">
-              <input
-                type="checkbox"
-                class="swappable-async-await-checkbox"
-                id="async-await-swap-2"
-                value="0"
-                checked=""
-                name="async-await-swap-2"
-              />
-              <label for="async-await-swap-2"></label>
-            </div>
-          </div>
-          <pre
-            class="no-async swappable-async-await-code"
-          ><code class="javascript">const fastify = require('fastify')({ logger: true })
+                <div class="swappable-async-await">
+                    <div class="swap-button-box">
+                        <label for="async-await-swap-2">async/await</label>
+                        <div class="toggle-checkbox">
+                            <input type="checkbox" class="swappable-async-await-checkbox" id="async-await-swap-2"
+                                value="0" checked="" name="async-await-swap-2" />
+                            <label for="async-await-swap-2"></label>
+                        </div>
+                    </div>
+                    <pre class="no-async swappable-async-await-code"><code class="javascript">const fastify = require('fastify')({ logger: true })
 
 fastify.route({
   method: 'GET',
@@ -236,9 +195,7 @@ fastify.listen(3000, (err) => {
   }
   fastify.log.info(`server listening on ${fastify.server.address().port}`)
 })</code></pre>
-          <pre
-            class="async swappable-async-await-code"
-          ><code class="javascript">const fastify = require('fastify')({ logger: true })
+                    <pre class="async swappable-async-await-code"><code class="javascript">const fastify = require('fastify')({ logger: true })
 
 fastify.route({
   method: 'GET',
@@ -277,226 +234,215 @@ const start = async () => {
   }
 }
 start()</code></pre>
-        </div>
+                </div>
 
-        <p>
-          Visit the <a href="/docs">Documentation</a> to learn more about all
-          the features that Fastify has to offer.
-        </p>
-      </div>
+                <p>
+                    Visit the <a href="/docs">Documentation</a> to learn more about all
+                    the features that Fastify has to offer.
+                </p>
+            </div>
+        </div>
     </div>
-  </div>
 </section>
 
 <section class="section">
-  <div class="container content">
-    <div class="columns is-centered">
-      <div class="column is-10">
-        <h1 class="title">Core features</h1>
+    <div class="container content">
+        <div class="columns is-centered">
+            <div class="column is-10">
+                <h1 class="title">Core features</h1>
 
-        <p>
-          These are the main features and principles on which fastify has been
-          built:
-        </p>
+                <p>
+                    These are the main features and principles on which fastify has been
+                    built:
+                </p>
 
-        <ul>
-          <li>
-            <strong>Highly performant:</strong> as far as we know, Fastify is
-            one of the fastest web frameworks in town, depending on the code
-            complexity we can serve up to 30 thousand requests per second.
-          </li>
-          <li>
-            <strong>Extendible:</strong> Fastify is fully extensible via its
-            hooks, plugins and decorators.
-          </li>
-          <li>
-            <strong>Schema based:</strong> even if it is not mandatory we
-            recommend to use
-            <a href="http://json-schema.org/" target="_blank">JSON Schema</a> to
-            validate your routes and serialize your outputs, internally Fastify
-            compiles the schema in an highly performant function.
-          </li>
-          <li>
-            <strong>Logging:</strong> logs are extremely important but are
-            costly; we chose the best logger to almost remove this cost,
-            <a href="https://github.com/pinojs/pino" target="_blank">Pino</a>!
-          </li>
-          <li>
-            <strong>Developer friendly:</strong> the framework is built to be
-            very expressive and to help developers in their daily use, without
-            sacrificing performance and security.
-          </li>
-          <li>
-            <strong>TypeScript ready:</strong> we work hard to maintain a
-            <a
-              href="https://www.typescriptlang.org/"
-              aria-label="Link to TypeScript website"
-              >TypeScript</a
-            >
-            type declaration file so we can support the growing TypeScript
-            community.
-          </li>
-        </ul>
-      </div>
+                <ul>
+                    <li>
+                        <strong>Highly performant:</strong> as far as we know, Fastify is
+                        one of the fastest web frameworks in town, depending on the code
+                        complexity we can serve up to 30 thousand requests per second.
+                    </li>
+                    <li>
+                        <strong>Extendible:</strong> Fastify is fully extensible via its
+                        hooks, plugins and decorators.
+                    </li>
+                    <li>
+                        <strong>Schema based:</strong> even if it is not mandatory we
+                        recommend to use
+                        <a href="http://json-schema.org/" target="_blank">JSON Schema</a> to
+                        validate your routes and serialize your outputs, internally Fastify
+                        compiles the schema in an highly performant function.
+                    </li>
+                    <li>
+                        <strong>Logging:</strong> logs are extremely important but are
+                        costly; we chose the best logger to almost remove this cost,
+                        <a href="https://github.com/pinojs/pino" target="_blank">Pino</a>!
+                    </li>
+                    <li>
+                        <strong>Developer friendly:</strong> the framework is built to be
+                        very expressive and to help developers in their daily use, without
+                        sacrificing performance and security.
+                    </li>
+                    <li>
+                        <strong>TypeScript ready:</strong> we work hard to maintain a
+                        <a href="https://www.typescriptlang.org/" aria-label="Link to TypeScript website">TypeScript</a>
+                        type declaration file so we can support the growing TypeScript
+                        community.
+                    </li>
+                </ul>
+            </div>
+        </div>
     </div>
-  </div>
 </section>
 
 <section class="section alternate">
-  <div class="container content">
-    <div class="columns">
-      <div class="column is-6">
-        <h1 class="title">A fast web framework</h1>
-        <p>
-          Leveraging our experience with Node.js performance, Fastify has been
-          built from the ground up to be <strong>as fast as possible</strong>.
-          Have a look at our <a href="/benchmarks">benchmarks section</a> to
-          compare fastify performance to other common web frameworks.
-        </p>
-        <div class="block">
-          <p>
-            <a
-              class="button is-primary is-large is-flex-mobile"
-              href="/benchmarks"
-              >Checkout our benchmarks</a
-            >
-          </p>
+    <div class="container content">
+        <div class="columns">
+            <div class="column is-6">
+                <h1 class="title">A fast web framework</h1>
+                <p>
+                    Leveraging our experience with Node.js performance, Fastify has been
+                    built from the ground up to be <strong>as fast as possible</strong>.
+                    Have a look at our <a href="/benchmarks">benchmarks section</a> to
+                    compare fastify performance to other common web frameworks.
+                </p>
+                <div class="block">
+                    <p>
+                        <a class="button is-primary is-large is-flex-mobile" href="/benchmarks">Checkout our
+                            benchmarks</a>
+                    </p>
+                </div>
+            </div>
+            <div class="column is-6">
+                <h1 class="title">Ecosystem</h1>
+                <p>
+                    Fastify has an ever-growing ecosystem of plugins. Probably there is
+                    already a plugin for your favourite database or template language.
+                    Have a look at the <a href="/ecosystem">Ecosystem page</a> to navigate
+                    through the currently available plugins. Can't you find the plugin you
+                    are looking for? No problem,
+                    <a href="/docs/master/Plugins">it's very easy to write one</a>!
+                </p>
+                <div class="block">
+                    <!-- The counting change is here. -->
+                    <a class="button is-primary is-large is-flex-mobile" href="/ecosystem">Explore
+                        {{ data.ecosystem.plugins.corePlugins | length + data.ecosystem.plugins.communityPlugins | length }}
+                        plugins</a>
+                </div>
+            </div>
         </div>
-      </div>
-      <div class="column is-6">
-        <h1 class="title">Ecosystem</h1>
-        <p>
-          Fastify has an ever-growing ecosystem of plugins. Probably there is
-          already a plugin for your favourite database or template language.
-          Have a look at the <a href="/ecosystem">Ecosystem page</a> to navigate
-          through the currently available plugins. Can't you find the plugin you
-          are looking for? No problem,
-          <a href="/docs/master/Plugins">it's very easy to write one</a>!
-        </p>
-        <div class="block">
-          <a class="button is-primary is-large is-flex-mobile" href="/ecosystem"
-            >Explore
-            {{ data.ecosystem.plugins.corePlugins | length + data.ecosystem.plugins.communityPlugins | length }}
-            plugins</a
-          >
-        </div>
-      </div>
     </div>
-  </div>
 </section>
 
 <section class="section team">
-  <div class="container">
-    <div class="columns is-centered">
-      <div class="column is-10">
-        <div class="content">
-          <h1 class="title">The team</h1>
-          <p>In alphabetical order</p>
-        </div>
-        {% for section in data.team %}
-        <div class="content">
-          <h2>{{ section.name }}</h2>
-        </div>
-        <div class="columns is-multiline">
-          {% for member in section.people | sort(false, false, 'sortname') %}
-          <div class="column is-one-third">
-            <div class="media">
-              <div class="media-left">
-                <figure class="image is-48x48">
-                  <img
-                    src="{{ member.picture }}"
-                    alt="{{ member.name }}'s profile picture"
-                  />
-                </figure>
-              </div>
-              <div class="media-content">
-                <p class="title is-5">{{ member.name }}</p>
-                <p class="subtitle is-6">
-                  {% for label, link in member.links %}
-                  <a href="{{ link }}" target="_blank">{{ label }}</a>
-                  {% endfor %}
-                </p>
-              </div>
-            </div>
-          </div>
-          {% endfor %}
-        </div>
-        {% endfor %}
+    <div class="container">
+        <div class="columns is-centered">
+            <div class="column is-10">
+                <div class="content">
+                    <h1 class="title">The team</h1>
+                    <p>In alphabetical order</p>
+                </div>
+                {% for section in data.team %}
+                <div class="content">
+                    <h2>{{ section.name }}</h2>
+                </div>
+                <div class="columns is-multiline">
+                    {% for member in section.people | sort(false, false, 'sortname') %}
+                    <div class="column is-one-third">
+                        <div class="media">
+                            <div class="media-left">
+                                <figure class="image is-48x48">
+                                    <img src="{{ member.picture }}" alt="{{ member.name }}'s profile picture" />
+                                </figure>
+                            </div>
+                            <div class="media-content">
+                                <p class="title is-5">{{ member.name }}</p>
+                                <p class="subtitle is-6">
+                                    {% for label, link in member.links %}
+                                    <a href="{{ link }}" target="_blank">{{ label }}</a>
+                                    {% endfor %}
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    {% endfor %}
+                </div>
+                {% endfor %}
 
-        <div class="content">
-          <hr />
-          <h1 class="title">Acknowledgments</h1>
-          <p>This project is kindly <strong>sponsored by</strong>:</p>
-          <ul>
-            {% for link in data.acknowledgements.sponsors %}
-            <li>
-              <a href="{{ link.url }}" target="_blank">{{ link.name }}</a>
-            </li>
-            {% endfor %}
-          </ul>
-          <p>Past Sponsors:</p>
-          <ul>
-            {% for link in data.acknowledgements.past_sponsors %}
-            <li>
-              <a href="{{ link.url }}" target="_blank">{{ link.name }}</a
-              >{% if link.reason %} ({{ link.reason }}){% endif %}
-            </li>
-            {% endfor %}
-          </ul>
-          <p>Also thanks to:</p>
-          <ul>
-            {% for link in data.acknowledgements.others %}
-            <li>
-              <a href="{{ link.url }}" target="_blank">{{ link.name }}</a
-              >{% if link.reason %} ({{ link.reason }}){% endif %}
-            </li>
-            {% endfor %}
-          </ul>
+                <div class="content">
+                    <hr />
+                    <h1 class="title">Acknowledgments</h1>
+                    <p>This project is kindly <strong>sponsored by</strong>:</p>
+                    <ul>
+                        {% for link in data.acknowledgements.sponsors %}
+                        <li>
+                            <a href="{{ link.url }}" target="_blank">{{ link.name }}</a>
+                        </li>
+                        {% endfor %}
+                    </ul>
+                    <p>Past Sponsors:</p>
+                    <ul>
+                        {% for link in data.acknowledgements.past_sponsors %}
+                        <li>
+                            <a href="{{ link.url }}" target="_blank">{{ link.name }}</a>{% if link.reason %}
+                            ({{ link.reason }}){% endif %}
+                        </li>
+                        {% endfor %}
+                    </ul>
+                    <p>Also thanks to:</p>
+                    <ul>
+                        {% for link in data.acknowledgements.others %}
+                        <li>
+                            <a href="{{ link.url }}" target="_blank">{{ link.name }}</a>{% if link.reason %}
+                            ({{ link.reason }}){% endif %}
+                        </li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            </div>
         </div>
-      </div>
     </div>
-  </div>
 </section>
 {% endblock %} {% block extraScripts %}
 <script type="text/javascript">
-  (function() {
-    var state = { preferAsync: true };
-    function getAsyncToggles() {
-      return document.getElementsByClassName("swappable-async-await-checkbox");
-    }
+    (function () {
+        var state = { preferAsync: true };
+        function getAsyncToggles() {
+            return document.getElementsByClassName("swappable-async-await-checkbox");
+        }
 
-    function getCodeBlocks() {
-      return document.getElementsByClassName("swappable-async-await-code");
-    }
+        function getCodeBlocks() {
+            return document.getElementsByClassName("swappable-async-await-code");
+        }
 
-    function initAsyncToggle() {
-      var toggles = getAsyncToggles();
-      for (var i = 0; i < toggles.length; i++) {
-        toggles.item(i).addEventListener("change", function(e) {
-          state.preferAsync = e.target.checked;
-          updateView();
-        });
-      }
-    }
+        function initAsyncToggle() {
+            var toggles = getAsyncToggles();
+            for (var i = 0; i < toggles.length; i++) {
+                toggles.item(i).addEventListener("change", function (e) {
+                    state.preferAsync = e.target.checked;
+                    updateView();
+                });
+            }
+        }
 
-    function updateView() {
-      var toggles = getAsyncToggles();
-      for (var i = 0; i < toggles.length; i++) {
-        toggles.item(i).checked = state.preferAsync;
-      }
+        function updateView() {
+            var toggles = getAsyncToggles();
+            for (var i = 0; i < toggles.length; i++) {
+                toggles.item(i).checked = state.preferAsync;
+            }
 
-      var codeBlocks = getCodeBlocks();
-      for (var i = 0; i < codeBlocks.length; i++) {
-        var block = codeBlocks.item(i);
-        var show =
-          (block.className.indexOf("async") === 0 && state.preferAsync) ||
-          (block.className.indexOf("no-async") === 0 && !state.preferAsync);
-        block.style.display = show ? "block" : "none";
-      }
-    }
+            var codeBlocks = getCodeBlocks();
+            for (var i = 0; i < codeBlocks.length; i++) {
+                var block = codeBlocks.item(i);
+                var show =
+                    (block.className.indexOf("async") === 0 && state.preferAsync) ||
+                    (block.className.indexOf("no-async") === 0 && !state.preferAsync);
+                block.style.display = show ? "block" : "none";
+            }
+        }
 
-    initAsyncToggle();
-    updateView();
-  })();
+        initAsyncToggle();
+        updateView();
+    })();
 </script>
 {% endblock %}

--- a/src/website/layouts/home.html
+++ b/src/website/layouts/home.html
@@ -324,7 +324,7 @@ start()</code></pre>
                     <a href="/docs/master/Plugins">it's very easy to write one</a>!
                 </p>
                 <div class="block">
-                    <!-- The counting change is here. -->
+                    <!-- TAG: Change here -->
                     <a class="button is-primary is-large is-flex-mobile" href="/ecosystem">Explore
                         {{ data.ecosystem.plugins.corePlugins | length + data.ecosystem.plugins.communityPlugins | length }}
                         plugins</a>


### PR DESCRIPTION
The "Explore Plugin" button on the homepage of the website shows "Explore 2 plugins" although it is supposed to be 36 (core) + 72 (community) = 108 plugins, because when earlier I explored the website it used to show the correct counts of the plugin.

After cloning and running the website I found out that the statement ( `data.ecosystem.plugins | length` ) to count the number of plugins
in **home.html** was only counting the types of plugin (core + community = 2) and not the actual plugins, as actual plugins were nested as "plugins>corePlugins>all_Core_Plugins" and "plugins>communityPlugins>all_Community_Plugins"

**Wrong count**\
![wrong-count](https://user-images.githubusercontent.com/38346914/59151211-cba13c80-8a4c-11e9-9c87-03a33aef5443.png)




I changed the statement to (`data.ecosystem.plugins.corePlugins | length + data.ecosystem.plugins.communityPlugins | length`) so that it can count the actual total plugins.


**Fixed count**



![right-count](https://user-images.githubusercontent.com/38346914/59151238-4b2f0b80-8a4d-11e9-8539-98b83b80e69f.png)
