### PR TITLE
Changed the plugin count statement

### DIFF
--- a/src/website/layouts/home.html
+++ b/src/website/layouts/home.html
@@ -261,7 +261,8 @@ start()</code></pre>
           Can't you find the plugin you are looking for? No problem, <a href="/docs/master/Plugins">it's very easy to write one</a>!
         </p>
         <div class="block">
-          <a class="button is-primary is-large is-flex-mobile" href="/ecosystem">Explore {{ data.ecosystem.plugins | length }} plugins</a>
+	  <!-- TAG: "Changed the statement to count plugins" -->
+          <a class="button is-primary is-large is-flex-mobile" href="/ecosystem">Explore {{ data.ecosystem.plugins.corePlugins | length + data.ecosystem.plugins.communityPlugins | length }} plugins</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Cloned PR reason: https://github.com/fastify/website/pull/129#issuecomment-500225131



The "Explore Plugin" button on the homepage of the website shows "Explore 2 plugins" although it is supposed to be 36 (core) + 72 (community) = 108 plugins, because when earlier I explored the website it used to show the correct counts of the plugin.

After cloning and running the website I found out that the statement ( `data.ecosystem.plugins | length` ) to count the number of plugins
in **home.html** was only counting the types of plugin (core + community = 2) and not the actual plugins, as actual plugins were nested as "plugins>corePlugins>all_Core_Plugins" and "plugins>communityPlugins>all_Community_Plugins"

**Wrong count** \
\
![wrong-count](https://user-images.githubusercontent.com/38346914/59151211-cba13c80-8a4c-11e9-9c87-03a33aef5443.png)



I changed the statement to (`data.ecosystem.plugins.corePlugins | length + data.ecosystem.plugins.communityPlugins | length`) so that it can count the actual total plugins.


**Fixed count**



![right-count](https://user-images.githubusercontent.com/38346914/59151238-4b2f0b80-8a4d-11e9-8539-98b83b80e69f.png)
