### PR TITLE
Changed beforeHandler to preHandler in validation example

### DIFF
--- a/src/website/layouts/home.html
+++ b/src/website/layouts/home.html
@@ -158,7 +158,7 @@ fastify.route({
     }
   },
   // this function is executed for every request before the handler is executed
-  beforeHandler: (request, reply, done) => {
+  preHandler: (request, reply, done) => {
     // E.g. check authentication
     done()
   },


### PR DESCRIPTION
Since `beforeHandler` is deprecated the Request/Response validation and hooks example on the homepage should be updated to use the `preHandler` hook.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
