### PR TITLE
Fix docs page layout

### DIFF
--- a/src/website/layouts/docs_page.html
+++ b/src/website/layouts/docs_page.html
@@ -50,7 +50,7 @@
         </aside>
       </div>
 
-      <div class="column">
+      <div class="column is-9">
         <nav class="breadcrumb">
           <ul>
             <li><a href="/" style="padding-left: 0">Fastify</a></li>


### PR DESCRIPTION
This pull request fixes #141.

I use https://bulma.io/documentation/columns/sizes/#12-columns-system to set proper size of the column.

Result:
![Screenshot 2020-01-11 at 12 05 24](https://user-images.githubusercontent.com/59734442/72202692-34c9b200-346b-11ea-900b-107048f15183.png)

I'm open for changes/discussion if you want it to look differently 🙂