### PR TITLE
Improve team section with vertical centering of names and links

### DIFF
--- a/src/website/content/css/style.scss
+++ b/src/website/content/css/style.scss
@@ -265,3 +265,7 @@ a > code {
     transform: rotate(360deg);
   }
 }
+
+.media.v-center {
+  align-items: center;
+}

--- a/src/website/layouts/home.html
+++ b/src/website/layouts/home.html
@@ -365,7 +365,7 @@ server.listen(3000, (err) => {
           <div class="columns is-multiline">
             {% for member in section.people | sort(false, false, 'sortname') %}
               <div class="column is-one-third">
-                <div class="media">
+                <div class="media v-center">
                   <div class="media-left">
                     <figure class="image is-96x96 contributor-picture">
                       <img src="{{ member.picture }}" alt="{{ member.name }}'s profile picture">


### PR DESCRIPTION
Small visual improvement in the Team section by aligning names and links vertically to the team pictures.

See changes here:

## From

![Screenshot 2020-03-17 at 11 06 55](https://user-images.githubusercontent.com/205629/76850772-f58b5900-683f-11ea-8bda-96f67a9542e9.png)


## To
  
![Screenshot 2020-03-17 at 11 05 09](https://user-images.githubusercontent.com/205629/76850788-fde39400-683f-11ea-8d90-5b4951155e85.png)
