### PR TITLE
Fix typo in why section of home

### DIFF
--- a/src/website/layouts/home.html
+++ b/src/website/layouts/home.html
@@ -22,7 +22,7 @@
         <h1 class="title">Why</h1>
         <p>
           An efficient server implies a lower cost of the infrastructure, a better responsiveness under load and happy users.
-          How can you efficiently handle the resources of your server, knowing that you are serving the highest number of requests as possible, without sacrificing security validations and handy development?
+          How can you efficiently handle the resources of your server, knowing that you are serving the highest number of requests possible, without sacrificing security validations and handy development?
         </p>
         <p>
           Enter Fastify. Fastify is a web framework highly focused on providing the best developer experience with the least overhead and a powerful plugin architecture.


### PR DESCRIPTION
Just an 'as' that shouldn't be there.