### PR TITLE
Fix: supports relative paths in ToC entries

### DIFF
--- a/src/scripts/processReleases.js
+++ b/src/scripts/processReleases.js
@@ -46,11 +46,11 @@ async function extractTOCFromFile (file, release) {
   // searches for the beginning of the ToC in the file (between '## Documentation' and '\n\n')
   const lines = fileContent.split('## Documentation')[1].split('\n\n')[0].split('\n').filter(Boolean)
   // every line is a ToC entry
-  const re = /master\/docs\/([a-zA-Z-0-9]+\.md)"><code><b>(.+)<\/b>/
+  const re = /(master|.)\/docs\/([a-zA-Z-0-9]+\.md)"><code><b>(.+)<\/b>/
   const toc = lines.map((line) => {
     const match = re.exec(line)
-    const fileName = match[1]
-    const name = match[2]
+    const fileName = match[2]
+    const name = match[3]
     const sourceFile = join(dirname(file), 'docs', fileName)
     const destinationFile = join(destFolder, 'content', 'docs', release.docsPath, fileName)
     const slug = basename(sourceFile, '.md')


### PR DESCRIPTION
This change should fix a build issue that appeared recently.

Apparently, we are currently using a different format to link pages in the Table of Contents (ToC), so the current build script broke.

Changes were introduced here: https://github.com/fastify/fastify/pull/2274/files


As you can see in that PR, we switched from a format like the following (absolute):

```markdown
* <a href="https://github.com/fastify/fastify/blob/master/docs/Getting-Started.md"><code><b>Getting Started</b></code></a>
```

To a relative format like the following:

```markdown
* <a href="./docs/Getting-Started.md"><code><b>Getting Started</b></code></a>
```

These changes broke the parsing of the ToC.

This PR fixes this problem in a backward compatible way, so we can still build old versions of the documentation.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
