### PR TITLE
Added pinned organisation features

### DIFF
--- a/src/scripts/buildWebsite.js
+++ b/src/scripts/buildWebsite.js
@@ -41,6 +41,19 @@ env.addGlobal('getContext', function () {
 env.addGlobal('currentYear', new Date().getFullYear())
 env.addFilter('md', markdownFilter)
 env.addFilter('shuffle', arr => shuffle(arr))
+env.addFilter('shuffleWithPinned', arr => {
+  const pinned = []
+  const remaining = []
+  for (const e of arr) {
+    if (e.pinned === true) {
+      pinned.push(e)
+    } else {
+      remaining.push(e)
+    }
+  }
+
+  return [...pinned, ...shuffle(remaining)]
+})
 
 Metalsmith(source)
   .source(path.join(source, 'content'))

--- a/src/website/data/organisations.yml
+++ b/src/website/data/organisations.yml
@@ -29,6 +29,7 @@
 - name: "Microsoft"
   image: "microsoft.svg"
   link: "https://docs.microsoft.com"
+  pinned: true
 
 - name: "Mr Porter"
   image: "mrp.svg"

--- a/src/website/layouts/home.html
+++ b/src/website/layouts/home.html
@@ -45,7 +45,7 @@
     <div class="columns is-centered">
       <div class="column is-12">
         <ul class="organisations-list">
-          {% set shuffledOrganisations = data.organisations | shuffle %}
+          {% set shuffledOrganisations = data.organisations | shuffleWithPinned %}
           {% for organizationIndex in range(0, 12) %}
             {% set organization = shuffledOrganisations[organizationIndex] %}
             {% if organization %}

--- a/src/website/layouts/organisations.html
+++ b/src/website/layouts/organisations.html
@@ -18,7 +18,7 @@
 				<p>Fastify is proudly powering a large ecosystem of organisations and products out there.</p>
 				<p>Below is a list of some of the organisations adopting Fastify.</p>
 				<ul class="organisations-list align-start">
-					{% for organization in data.organisations | shuffle %}
+					{% for organization in data.organisations | shuffleWithPinned %}
 						<li>
 							<a href="{{ organization.link }}" target="_blank" rel="nofollow">
 								<img src="/{{ hashes['images/organisations/' + organization.image] }}" alt="{{ organization.name }} is using Fastify"/>


### PR DESCRIPTION
This PR implements a feature that allows us to pin specific organisations in the home page and in the organisations' page so that they will always be displayed first and not be shuffled with the rest of the (non-pinned) orgs.

This feature was originally discussed in #193. 