### PR TITLE
Fix home's TypesScript example

### DIFF
--- a/src/website/layouts/home.html
+++ b/src/website/layouts/home.html
@@ -314,20 +314,23 @@ server.get('/ping', opts, async (request, reply) => {
   return { pong: 'it worked!' }
 })
 
-server.listen(3000, (err) => {
-  if (err) {
+const start = async () => {
+  try {
+    await server.listen(3000)
+
+    const { port } = server.server.address() as {
+      address: string;
+      family: string;
+      port: number;
+    }
+
+    server.log.info(`server listening on ${port}`)
+  } catch (err) {
     server.log.error(err)
     process.exit(1)
   }
-
-  const { port } = server.server.address() as {
-    address: string;
-    family: string;
-    port: number;
-  }
-
-  server.log.info(`server listening on ${port}`)
-})</code></pre>
+}
+start()</code></pre>
 				</div>
 
         <p>Visit the <a href="/docs">Documentation</a> to learn more about all the features that Fastify has to offer.</p>

--- a/src/website/layouts/home.html
+++ b/src/website/layouts/home.html
@@ -282,11 +282,8 @@ server.listen(3000, (err) => {
     process.exit(1)
   }
 
-  const { port } = server.server.address() as {
-    address: string;
-    family: string;
-    port: number;
-  }
+  const address = server.server.address()
+  const port = typeof address === 'string' ? address : address?.port
 
   server.log.info(`server listening on ${port}`)
 })</code></pre>
@@ -318,11 +315,8 @@ const start = async () => {
   try {
     await server.listen(3000)
 
-    const { port } = server.server.address() as {
-      address: string;
-      family: string;
-      port: number;
-    }
+    const address = server.server.address()
+    const port = typeof address === 'string' ? address : address?.port
 
     server.log.info(`server listening on ${port}`)
   } catch (err) {

--- a/src/website/layouts/home.html
+++ b/src/website/layouts/home.html
@@ -255,7 +255,7 @@ start()</code></pre>
           <pre class="no-async swappable-async-await-code"><code class="javascript">import * as fastify from 'fastify'
 import { Server, IncomingMessage, ServerResponse } from 'http'
 
-const server: fastify.FastifyInstance<Server, IncomingMessage, ServerResponse> = fastify({})
+const server: fastify.FastifyInstance<Server, IncomingMessage, ServerResponse> = fastify.fastify({})
 
 const opts: fastify.RouteShorthandOptions = {
   schema: {
@@ -281,12 +281,19 @@ server.listen(3000, (err) => {
     server.log.error(err)
     process.exit(1)
   }
-  server.log.info(`server listening on ${server.server.address().port}`)
+
+  const { port } = server.server.address() as {
+    address: string;
+    family: string;
+    port: number;
+  }
+
+  server.log.info(`server listening on ${port}`)
 })</code></pre>
           <pre class="async swappable-async-await-code"><code class="javascript">import * as fastify from 'fastify'
 import { Server, IncomingMessage, ServerResponse } from 'http'
 
-const server: fastify.FastifyInstance<Server, IncomingMessage, ServerResponse> = fastify({})
+const server: fastify.FastifyInstance<Server, IncomingMessage, ServerResponse> = fastify.fastify({})
 
 const opts: fastify.RouteShorthandOptions = {
   schema: {
@@ -312,7 +319,14 @@ server.listen(3000, (err) => {
     server.log.error(err)
     process.exit(1)
   }
-  server.log.info(`server listening on ${server.server.address().port}`)
+
+  const { port } = server.server.address() as {
+    address: string;
+    family: string;
+    port: number;
+  }
+
+  server.log.info(`server listening on ${port}`)
 })</code></pre>
 				</div>
 

--- a/src/website/layouts/home.html
+++ b/src/website/layouts/home.html
@@ -252,12 +252,12 @@ start()</code></pre>
 							<label for="async-await-swap-3"></label>
             </div>
           </div>
-          <pre class="no-async swappable-async-await-code"><code class="javascript">import * as fastify from 'fastify'
+          <pre class="no-async swappable-async-await-code"><code class="javascript">import Fastify, { FastifyInstance, RouteShorthandOptions } from 'fastify'
 import { Server, IncomingMessage, ServerResponse } from 'http'
 
-const server: fastify.FastifyInstance<Server, IncomingMessage, ServerResponse> = fastify.fastify({})
+const server: FastifyInstance<Server, IncomingMessage, ServerResponse> = Fastify({})
 
-const opts: fastify.RouteShorthandOptions = {
+const opts: RouteShorthandOptions = {
   schema: {
     response: {
       200: {
@@ -290,12 +290,12 @@ server.listen(3000, (err) => {
 
   server.log.info(`server listening on ${port}`)
 })</code></pre>
-          <pre class="async swappable-async-await-code"><code class="javascript">import * as fastify from 'fastify'
+          <pre class="async swappable-async-await-code"><code class="javascript">import Fastify, { FastifyInstance, RouteShorthandOptions } from 'fastify'
 import { Server, IncomingMessage, ServerResponse } from 'http'
 
-const server: fastify.FastifyInstance<Server, IncomingMessage, ServerResponse> = fastify.fastify({})
+const server: FastifyInstance<Server, IncomingMessage, ServerResponse> = Fastify({})
 
-const opts: fastify.RouteShorthandOptions = {
+const opts: RouteShorthandOptions = {
   schema: {
     response: {
       200: {


### PR DESCRIPTION
Fix:
- `fastify({})` is not a function, `fastify.fastify({})` is.
- Directly accessing the port via `server.server.address().port`
  would lead to a type error. `server.server.address()` has type
  `string | AddressInfo`, and `string` does not have the `port`
  property. The new cast prevents this error.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
