### PR TITLE
Improve ecosystem parsing to support namespaced package names

### DIFF
--- a/src/scripts/processReleases.js
+++ b/src/scripts/processReleases.js
@@ -220,10 +220,9 @@ const extractPlugins = (pluginContent) => {
     }
     return acc
   }, [])
-  const re = /\[`([-a-zA-Z0-9.]+)`\]\(([^)]+)\)(\s*(.+))?/
+  const re = /\[`([-a-zA-Z0-9./@]+)`\]\(([^)]+)\)(\s*(.+))?/
   const plugins = mergedLines.map((line) => {
     const match = re.exec(line)
-
     const name = match[1]
     const url = match[2]
     const description = match[3] ? match[3].trim() : ''


### PR DESCRIPTION
The changes here allow support for namespaced packages in the ecosystem section (e.g. `@namespace/package-name`).

This is done by expanding the regex that processes the list of packages from the readme:

![Screenshot 2020-10-31 at 10 49 46](https://user-images.githubusercontent.com/205629/97777279-04244780-1b67-11eb-8cb8-04714bbab386.png)

https://regex101.com/r/hxNuCp/1/

This will address failing builds as observed also in #209