### PR TITLE
Add support for nested documentation sections (like Guides)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,5 @@ build/
 # excludes dynamically generated content
 src/website/data/docs.yml
 src/website/data/ecosystem.yml
-src/website/content/docs/*/*.md
+src/website/content/docs/**/*.md
 .DS_Store

--- a/src/scripts/processReleases.js
+++ b/src/scripts/processReleases.js
@@ -171,6 +171,8 @@ version: ${item.version}
 fullVersion: ${item.fullVersion}
 label: ${item.label}
 docsPath: ${item.docsPath}
+prefixParts: ${JSON.stringify(item.prefix)}
+prefixPath: ${item.prefix.join('/')}/
 ${item.version === 'latest' ? `canonical: "${item.link.replace(/latest/, latestRelease.label)}"` : ''}
 ${item.version === 'master' ? `github_url: https://github.com/fastify/fastify/blob/master/docs/${item.fileName}` : ''}
 ---

--- a/src/scripts/processReleases.js
+++ b/src/scripts/processReleases.js
@@ -184,6 +184,7 @@ ${content}`
 function remapLinks (content, item) {
   /*
     Links remapping rules:
+    [XXX](/CONTRIBUTING.md) -> https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
     /https:\/\/github.com\/fastify\/fastify\/blob\/master\/docs/ -> /docs/[VERSION]
     [XXXX](Plugins.md) -> [XXXX](/docs/[VERSION]/Plugins)
     [XXXX](/docs/VVVV/Ecosystem.md) -> [XXXX](/ecosystem)
@@ -192,14 +193,16 @@ function remapLinks (content, item) {
     [XXXX](./YYYY "ZZZZ") -> [XXXX]('/docs/[VERSION]/YYYY' "ZZZZ")
     href="https://github.com/fastify/fastify/blob/master/docs/YYYY.md -> href="/docs/[VERSION]/YYYY
   */
+  const contributingLinkRx = /\/CONTRIBUTING\.md/gi
   const ecosystemLinkRx = /\(\/docs\/[\w\d.-]+\/Ecosystem\.md\)/gi
-  const docInternalLinkRx = /\(\/docs\/[\w\d.-]+\/[\w\d-]+(.md)/gi
-  const pluginsLink = /\(Plugins.md\)/gi
+  const docInternalLinkRx = /\(\/docs\/[\w\d.-]+\/[\w\d-]+(\.md)/gi
+  const pluginsLink = /\(Plugins\.md\)/gi
   const relativeLinks = /\((.\/)?(([a-zA-Z0-9\-_]+).md(#[a-z0-9\-_]+)?)\)/gi
   const relativeLinksWithLabel = /\('?(\.\/)([\w\d.-]+)(.md)'?\s+"([\w\d.-]+)"\)/gi
   const hrefAbsoluteLinks = /href="https:\/\/github\.com\/fastify\/fastify\/blob\/master\/docs\/([\w\d.-]+)\.md/gi
   const absoluteLinks = /https:\/\/github.com\/fastify\/fastify\/blob\/master\/docs/gi
   return content
+    .replace(contributingLinkRx, () => 'https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md')
     .replace(hrefAbsoluteLinks, (match, p1) => `href="/docs/${item.version}/${p1}`)
     .replace(absoluteLinks, `/docs/${item.version}`)
     .replace(ecosystemLinkRx, (match) => '(/ecosystem)')

--- a/src/scripts/processReleases.js
+++ b/src/scripts/processReleases.js
@@ -99,7 +99,6 @@ async function extractTOCFromFile (file, release, docsBase, prefix = []) {
   // if any link to /<subsection>/<file>.md was found
   // assume there is a new subtree that needs to be discovered and processed
   // assume the tree ToC is stored in Index.md inside the current prefix + subsection
-  console.log(subsections)
   for (const subsection of subsections) {
     const innerIndex = join(dirname(file), 'docs', subsection, 'Index.md')
     const innerPrefix = [...prefix, subsection]

--- a/src/website/layouts/docs_page.html
+++ b/src/website/layouts/docs_page.html
@@ -1,63 +1,47 @@
 {% extends "default.html" %}
 
 {% block content %}
-<section class="hero is-primary" style="background-image: url(/{{ hashes['images/bg-pattern-dark.png'] }})">
-  <div class="hero-body">
+  <section class="hero is-primary" style="background-image: url(/{{ hashes['images/bg-pattern-dark.png'] }})">
+    <div class="hero-body">
       <div class="container">
         <h1 class="title">
           {% set versionTitle = fullVersion %}
           {% if version == 'latest' %}
-            {% set versionTitle = 'latest — ' + data.docs.releases[0].fullVersion %}
+            {% set versionTitle = 'latest — ' + data
+              .docs
+              .releases[0]
+              .fullVersion %}
           {% endif %}
           Documentation ({{ versionTitle }})
         </h1>
       </div>
-  </div>
-</section>
+    </div>
+  </section>
 
-<section class="section">
-	<div class="container">
-    <div class="columns">
+  <section class="section">
+    <div class="container">
+      <div class="columns">
 
-      <div class="column is-3 is-hidden-mobile" data-sticky-container>
-        <aside class="menu sticky">
-          <p class="menu-label">
+        <div class="column is-3 is-hidden-mobile" data-sticky-container>
+          <aside class="menu sticky">
+            <p class="menu-label">
             Table of contents
           </p>
-          <ul class="menu-list">
-            {% for item in data.docs.toc[version] %}
-              <li {% if item.link == '/' + path %}id="doc-menu-section"{% endif %}>
-                <a title="{{ item.name | striptags }}" {% if item.link == '/' + path %}class="is-active"{% endif %} href="{{ item.link }}">{{ item.name }}</a>
-              </li>
-            {% endfor %}
-          </ul>
-          <div class="content" style="margin: .8em; border-top: 1px solid #ccc; padding: .8em 0 0 0">
+            <ul class="menu-list">
+              {% for item in data
+                .docs
+                .toc[version] %}
+                <li {% if item.link == '/' + path %}id="doc-menu-section"{% endif %}>
+                  <a title="{{ item.name | striptags }}" {% if item.link == '/' + path %}class="is-active"{% endif %} href="{{ item.link }}">{{ item.name }}</a>
+                </li>
+              {% endfor %}
+            </ul>
+            <div class="content" style="margin: .8em; border-top: 1px solid #ccc; padding: .8em 0 0 0">
             Docs version
             <div class="field">
-              <div class="control">
-                <div class="select">
-                  <select onchange="if (this.value) window.location.href=this.value">
-                    {% for v in data.docs.versions %}
-                      <option {% if docsPath == v %}selected="selected"{% endif %} value="/docs/{{ v }}">{{ v }}</option>
-                    {% endfor %}
-                  </select>
-                </div>
-              </div>
-            </div>
-          </div>
-        </aside>
-      </div>
-
-      <div class="column is-9">
-        <nav class="breadcrumb">
-          <ul>
-            <li><a href="/" style="padding-left: 0">Fastify</a></li>
-            <li><a href="/docs/">Documentation</a></li>
-            <li>
-              <div class="field">
                 <div class="control">
                   <div class="select">
-                    <select onchange="if (this.value) window.location.href=this.value" style="border: none;">
+                    <select onchange="if (this.value) window.location.href=this.value">
                       {% for v in data.docs.versions %}
                         <option {% if docsPath == v %}selected="selected"{% endif %} value="/docs/{{ v }}">{{ v }}</option>
                       {% endfor %}
@@ -65,75 +49,119 @@
                   </div>
                 </div>
               </div>
-            </li>
-            <li class="is-active"><a>{{ title }}</a></li>
-          </ul>
-        </nav>
-
-        <div id="doc-content" class="content">
-          {{ contents | safe }}
+            </div>
+          </aside>
         </div>
 
-        <hr/>
-        <nav class="level">
-        {% for item in data.docs.toc[version] %}
-          {% if item.link == '/' + path %}
-            <div class="level-left">
-              <div class="level-item">
-                {% if loop.first %}
+        <div class="column is-9">
+          <nav class="breadcrumb">
+            <ul>
+              <li>
+                <a href="/" style="padding-left: 0">Fastify</a>
+              </li>
+              <li>
+                <a href="/docs/">Documentation</a>
+              </li>
+              <li>
+                <div class="field">
+                  <div class="control">
+                    <div class="select">
+                      <select onchange="if (this.value) window.location.href=this.value" style="border: none;">
+                        {% for v in data.docs.versions %}
+                          <option {% if docsPath == v %}selected="selected"{% endif %} value="/docs/{{ v }}">{{ v }}</option>
+                        {% endfor %}
+                      </select>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              {% set partLink = "/docs/" + docsPath + "/" %}
+              {% for part in prefixParts %}
+                {% set partLink = partLink + part + "/" %}
+                <li>
+                  <a href="{{ partLink }}Index/">{{ part }}</a>
+                </li>
+              {% endfor %}
+              <li class="is-active">
+                <a>{{ title }}</a>
+              </li>
+            </ul>
+          </nav>
+
+          <div id="doc-content" class="content">
+            {{ contents | safe }}
+          </div>
+
+          <hr/>
+          <nav class="level">
+            {% for item in data
+              .docs
+              .toc[version] %}
+              {% if item.link == '/' + path %}
+                <div class="level-left">
+                  <div class="level-item">
+                    {% if loop.first %}
                   &nbsp;
                 {% else %}
-                  {% set previous = loop.index0 - 1 %}
-                  {% set previous_page = data.docs.toc[version][previous] %}
-                  <a href="{{ previous_page.link }}" class="button prev">≪ {{ previous_page.name }}</a>
-                {% endif %}
-              </div>
-            </div>
-            <div class="level-right">
-              <div class="level-item">
-                {% if loop.last %}
+                      {% set previous = loop.index0 - 1 %}
+                      {% set previous_page = data
+                        .docs
+                        .toc[version][previous] %}
+                      <a href="{{ previous_page.link }}" class="button prev">≪ {{ previous_page.name }}</a>
+                    {% endif %}
+                  </div>
+                </div>
+                <div class="level-right">
+                  <div class="level-item">
+                    {% if loop.last %}
                   &nbsp;
                 {% else %}
-                  {% set next = loop.index0 + 1 %}
-                  {% set next_page = data.docs.toc[version][next] %}
-                  <a href="{{ next_page.link }}" class="button next">{{ next_page.name }} ≫</a>
-                {% endif %}
-              </div>
-            </div>
-          {% endif %}
-        {% endfor %}
-        </nav>
+                      {% set next = loop.index0 + 1 %}
+                      {% set next_page = data
+                        .docs
+                        .toc[version][next] %}
+                      <a href="{{ next_page.link }}" class="button next">{{ next_page.name }} ≫</a>
+                    {% endif %}
+                  </div>
+                </div>
+              {% endif %}
+            {% endfor %}
+          </nav>
+        </div>
       </div>
-		</div>
-  </div>
-</section>
+    </div>
+  </section>
 
-<script>
-  // dynamically creates a submenu for the current section based on the content headers
-  var titles = document.querySelectorAll('#doc-content h3, #doc-content h4')
-  var currentMenu = document.getElementById('doc-menu-section')
-  if (titles.length && currentMenu) {
-    var submenu = document.createElement('ul')
-    titles.forEach(el => {
-      var currentSubmenuItem = document.createElement('li')
-      var currentSubmenuLink = document.createElement('a')
-      currentSubmenuLink.href = '#' + el.id
-      currentSubmenuLink.title = el.textContent
-      currentSubmenuLink.append(document.createTextNode(el.textContent))
-      currentSubmenuItem.append(currentSubmenuLink)
-      submenu.append(currentSubmenuItem)
+  <script>
+    // dynamically creates a submenu for the current section based on the content headers
+    var titles = document.querySelectorAll('#doc-content h3, #doc-content h4')
+    var currentMenu = document.getElementById('doc-menu-section')
+    if (titles.length && currentMenu) {
+      var submenu = document.createElement('ul')
+      titles.forEach(el => {
+        var currentSubmenuItem = document.createElement('li')
+        var currentSubmenuLink = document.createElement('a')
+        currentSubmenuLink.href = '#' + el.id
+        currentSubmenuLink.title = el
+          .textContent
+          currentSubmenuLink
+          .append(document.createTextNode(el.textContent))
+        currentSubmenuItem.append(currentSubmenuLink)
+        submenu.append(currentSubmenuItem)
+      })
+      currentMenu.append(submenu)
+    }
+
+    // dynamically creates header anchor links
+    var headers = document.querySelectorAll('#doc-content h3, #doc-content h4')
+    headers.forEach(el => {
+      var currentAnchorLink = document.createElement('a')
+      currentAnchorLink.className = 'anchor'
+      currentAnchorLink.href = "#" + el
+        .id
+        currentAnchorLink
+        .append(document.createTextNode('¶'))
+      el.insertBefore(currentAnchorLink, el.firstChild);
     })
-    currentMenu.append(submenu)
-  }
-
-  // dynamically creates header anchor links
-  var headers = document.querySelectorAll('#doc-content h3, #doc-content h4')
-  headers.forEach(el => {
-    var currentAnchorLink = document.createElement('a')
-    currentAnchorLink.className = 'anchor'
-    currentAnchorLink.href = "#" + el.id
-    currentAnchorLink.append(document.createTextNode('¶'))
-    el.insertBefore(currentAnchorLink, el.firstChild);
-  })
-</script>
+  </script>
 {% endblock %}


### PR DESCRIPTION
This PR adds support for nested documentation sections like what is currently being proposed with "Guides" in https://github.com/fastify/fastify/pull/2610/.

## Current status

Status: **DRAFT**

There are still some major issues with the current implementation and some more work to do.

See the following 2 pictures:

### Nested documentation section index (PIC1)

![Screenshot 2020-11-15 at 12 08 57](https://user-images.githubusercontent.com/205629/99184549-8c941200-273b-11eb-94a7-75b85a1de137.png)


### Nested documentation page (PIC2)

![Screenshot 2020-11-15 at 12 00 36](https://user-images.githubusercontent.com/205629/99184497-3030f280-273b-11eb-98b6-4cc06af5b0ee.png)






## TODO list

 - [ ] Fix broken links in nested documentation section index pages (PIC 1 issue 1)
 - [ ] Remove nested doc pages from top-level Table of Contents (PIC 1 issue 2)
 - [x] In nested documentation pages update breadcrumb menu as necessary (PIC 2 issue 1)
 - [x] Add special link remapping rule for `CONTRIBUTING.md` (PIC 2 issue 2)
 - [ ] In nested documentation pages show in the menu with the ToC only pages for the current section (PIC 2 issue 4)
 - [ ] Suggest necessary changes in https://github.com/fastify/fastify/pull/2610/ to comply with what expected in this implementation (e.g. how to define links in the index pages and markdown formatting issues as in PIC2 issue 3)
 - [ ] Try to move all the pages that belong to the API section to an `API` subfolder
 - [ ] Publish a draft release of the new docs with all the changes above and get help on testing