### PR TITLE
docs: fix unnecessary log

### DIFF
--- a/src/website/layouts/home.html
+++ b/src/website/layouts/home.html
@@ -115,7 +115,6 @@ fastify.listen(3000, (err) => {
     fastify.log.error(err)
     process.exit(1)
   }
-  fastify.log.info(`server listening on ${fastify.server.address().port}`)
 })</code></pre>
           <pre class="async swappable-async-await-code"><code class="javascript">// Require the framework and instantiate it
 const fastify = require('fastify')({ logger: true })
@@ -129,7 +128,6 @@ fastify.get('/', async (request, reply) => {
 const start = async () => {
   try {
     await fastify.listen(3000)
-    fastify.log.info(`server listening on ${fastify.server.address().port}`)
   } catch (err) {
     fastify.log.error(err)
     process.exit(1)
@@ -193,7 +191,6 @@ fastify.listen(3000, (err) => {
     fastify.log.error(err)
     process.exit(1)
   }
-  fastify.log.info(`server listening on ${fastify.server.address().port}`)
 })</code></pre>
           <pre class="async swappable-async-await-code"><code class="javascript">const fastify = require('fastify')({ logger: true })
 
@@ -227,7 +224,6 @@ fastify.route({
 const start = async () => {
   try {
     await fastify.listen(3000)
-    fastify.log.info(`server listening on ${fastify.server.address().port}`)
   } catch (err) {
     fastify.log.error(err)
     process.exit(1)
@@ -285,7 +281,6 @@ server.listen(3000, (err) => {
   const address = server.server.address()
   const port = typeof address === 'string' ? address : address?.port
 
-  server.log.info(`server listening on ${port}`)
 })</code></pre>
           <pre class="async swappable-async-await-code"><code class="javascript">import Fastify, { FastifyInstance, RouteShorthandOptions } from 'fastify'
 import { Server, IncomingMessage, ServerResponse } from 'http'
@@ -318,7 +313,6 @@ const start = async () => {
     const address = server.server.address()
     const port = typeof address === 'string' ? address : address?.port
 
-    server.log.info(`server listening on ${port}`)
   } catch (err) {
     server.log.error(err)
     process.exit(1)


### PR DESCRIPTION
Updating the code example on the website to remove the `server listening on port` message text since this is already the default behavior, and no further logging is required.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
