### PR TITLE
fix: change link color to increase accessibility

### DIFF
--- a/src/website/content/css/style.scss
+++ b/src/website/content/css/style.scss
@@ -1,6 +1,6 @@
 @charset "utf-8";
 
-$link: #04625C;
+$link: #00458b;
 $primary: #04625C;
 
 @import "../../../../node_modules/bulma/bulma.sass";

--- a/src/website/content/css/style.scss
+++ b/src/website/content/css/style.scss
@@ -1,6 +1,6 @@
 @charset "utf-8";
 
-$link: #00458b;
+$link: #00458B;
 $primary: #04625C;
 
 @import "../../../../node_modules/bulma/bulma.sass";
@@ -136,6 +136,10 @@ main.page-content {
   left: 1.1em;
 }
 
+a {
+  text-decoration: underline;
+}
+
 a.anchor {
   color: #808080;
   padding: 0 0 0 0.5rem;
@@ -146,8 +150,12 @@ a.anchor:hover {
   color: #4a4a4a;
 }
 
-a > code {
-  text-decoration: underline;
+a img, a svg {
+  border-bottom: none;
+}
+
+#main-navbar {
+  text-decoration: none;
 }
 
 #main-navbar .control.has-icons-left .icon.is-left {

--- a/src/website/content/css/style.scss
+++ b/src/website/content/css/style.scss
@@ -155,7 +155,9 @@ a img, a svg {
 }
 
 #main-navbar {
-  text-decoration: none;
+  a {
+    text-decoration: none;
+  }
 }
 
 #main-navbar .control.has-icons-left .icon.is-left {


### PR DESCRIPTION
Went for MDN's link colour as their site is quite accessible, though could also use the holy grail that is [gov.uk](https://www.gov.uk/)'s colour scheme as reference.

Closes #237 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
