### PR TITLE
Updates download reference for master documentation

### DIFF
--- a/src/scripts/downloadReleases.js
+++ b/src/scripts/downloadReleases.js
@@ -115,7 +115,7 @@ async function main () {
   selectedReleases.latest = { ...latestRelease, name: 'latest', docsPath: 'latest' }
 
   // Add current master
-  const masterUrl = `https://github.com/${repository}/archive/master.zip`
+  const masterUrl = `https://github.com/${repository}/archive/refs/heads/main.zip`
   selectedReleases.master = {
     label: 'master',
     name: 'master',


### PR DESCRIPTION
In reference to the changes being implemented in https://github.com/fastify/fastify/pull/2909, this change we'll be needed in order to keep processing the documentation for the "main" branch correctly.