### PR TITLE
fix: ecosystem link in docs folder

### DIFF
--- a/src/scripts/processReleases.js
+++ b/src/scripts/processReleases.js
@@ -147,6 +147,7 @@ function remapLinks (content, item) {
     Links remapping rules:
     /https:\/\/github.com\/fastify\/fastify\/blob\/master\/docs/ -> /docs/[VERSION]
     [XXXX](Plugins.md) -> [XXXX](/docs/[VERSION]/Plugins)
+    [XXXX](Ecosystem.md) -> [XXXX](/ecosystem)
     [XXXX](/docs/VVVV/Ecosystem.md) -> [XXXX](/ecosystem)
     [XXXX](/docs/VVVV/YYYY.md) -> [XXXX](/docs/VVVV/YYYY)
     [XXXX]('./YYYY' "ZZZZ") -> [XXXX]('/docs/[VERSION]/YYYY' "ZZZZ")
@@ -156,6 +157,7 @@ function remapLinks (content, item) {
   */
   const ecosystemLinkRx = /\(\/docs\/[\w\d.-]+\/Ecosystem\.md\)/gi
   const docInternalLinkRx = /\(\/docs\/[\w\d.-]+\/[\w\d-]+(.md)/gi
+  const ecosystemLink = /\(Ecosystem\.md\)/gi
   const pluginsLink = /\(Plugins.md\)/gi
   const relativeLinks = /\((.\/)?(([a-zA-Z0-9\-_]+).md(#[a-z0-9\-_]+)?)\)/gi
   const relativeLinksWithLabel = /\('?(\.\/)([\w\d.-]+)(.md)'?\s+"([\w\d.-]+)"\)/gi
@@ -166,6 +168,7 @@ function remapLinks (content, item) {
     .replace(hrefAbsoluteLinks, (match, p1) => `href="/docs/${item.version}/${p1}`)
     .replace(absoluteLinks, `/docs/${item.version}`)
     .replace(ecosystemLinkRx, (match) => '(/ecosystem)')
+    .replace(ecosystemLink, (match) => '(/ecosystem)')
     .replace(pluginsLink, (match) => `(/docs/${item.version}/Plugins)`)
     .replace(relativeLinks, (match, ...parts) => `(/docs/${item.version}/${parts[2]}${parts[3] || ''})`)
     .replace(relativeLinksWithLabel, (match, ...parts) => `(/docs/${item.version}/${parts[1]} "${parts[3]}")`)


### PR DESCRIPTION
https://github.com/fastify/fastify/search?q=Ecosystem.md
`Ecosystem.md` appear to be used in 2 location.

It is fixing the issue https://github.com/fastify/fastify/issues/2962

I am not sure if I should directly replace the `RegExp` for `ecosystemLinkRx`. Or just add the new one as this PR.


#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
