### PR TITLE
Renamed extendible to extensible

### DIFF
--- a/src/website/layouts/home.html
+++ b/src/website/layouts/home.html
@@ -79,7 +79,7 @@
 
         <ul>
           <li><strong>Highly performant:</strong> as far as we know, Fastify is one of the fastest web frameworks in town, depending on the code complexity we can serve up to 30 thousand requests per second.</li>
-          <li><strong>Extendible:</strong> Fastify is fully extensible via its hooks, plugins and decorators.</li>
+          <li><strong>Extensible:</strong> Fastify is fully extensible via its hooks, plugins and decorators.</li>
           <li><strong>Schema based:</strong> even if it is not mandatory we recommend to use <a href="http://json-schema.org/" target="_blank" rel="noopener">JSON Schema</a> to validate your routes and serialize your outputs, internally Fastify compiles the schema in a highly performant function.</li>
           <li><strong>Logging:</strong> logs are extremely important but are costly; we chose the best logger to almost remove this cost, <a href="https://github.com/pinojs/pino" target="_blank" rel="noopener">Pino</a>!</li>
           <li><strong>Developer friendly:</strong> the framework is built to be very expressive and to help developers in their daily use, without sacrificing performance and security.</li>


### PR DESCRIPTION
Although both (seem) to mean the same, I think it might have been a type to have two different words for the same thing, as the character "d" in `extendible` is right next to the character "s" in `extensible` on the keyboard ^^

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
