### PR TITLE
chore(.github): add github issue forms to stop inheritance of organization issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,45 @@
+name: 🐛 Bug report
+description: Create a report to help us improve
+
+body:
+
+  - type: markdown
+    attributes:
+      value: |
+        Before you submit an issue we recommend you visit [Fastify Help](https://github.com/fastify/help)
+        if you have any questions regarding using Fastify.
+
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      options:
+      - label: I have written a descriptive issue title
+        required: true
+      - label: | 
+          I have searched existing issues to ensure the bug has not already been reported
+        required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: |
+        List of steps that reproduces the behavior.
+        Make sure you place a stack trace inside a [code (```) block](https://docs.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks) to avoid linking unrelated issues.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected to happen.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions / Help
+    url: https://github.com/fastify/help
+    about: If you have questions, please check our Help repo

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,44 @@
+name: 🚀 Feature Proposal
+description: Submit a proposal for a new feature
+labels: ['feature request']
+
+body:
+
+  - type: markdown
+    attributes:
+      value: |
+        Before you submit an issue we recommend you visit [Fastify Help](https://github.com/fastify/help)
+        if you have any questions regarding using Fastify.
+
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      options:
+      - label: I have written a descriptive issue title
+        required: true
+      - label: | 
+          I have searched existing issues to ensure the feature has not already been requested
+        required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 🚀 Feature Proposal
+      description: A clear and concise description of what the feature is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: The motivation for the proposal.
+
+  - type: textarea
+    id: example
+    attributes:
+      label: Example
+      description: |
+        An example for how this feature would be used.
+        Make sure you place example code inside a [code (```) block](https://docs.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks) to avoid linking unrelated issues.

--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -1,0 +1,29 @@
+name: ❔ Other
+description: Open an issue that is not feature or bug related
+
+body:
+
+  - type: markdown
+    attributes:
+      value: |
+        Before you submit an issue we recommend you visit [Fastify Help](https://github.com/fastify/help)
+        if you have any questions regarding using Fastify.
+
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      options:
+      - label: I have written a descriptive issue title
+        required: true
+      - label: | 
+          I have searched existing issues to ensure the issue has not already been raised
+        required: true
+
+  - type: textarea
+    id: text
+    attributes:
+      label: Issue
+      description: |
+        Give as much detail as you can to help us understand.
+        Make sure you place example code inside a [code (```) block](https://docs.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks) to avoid linking unrelated issues.


### PR DESCRIPTION
Raised by https://github.com/fastify/.github/pull/11#issuecomment-913141621, the organization-wide issue forms found in [`.github`](https://github.com/fastify/.github) make little sense in relation to the `website` repo.

This PR stops inheritance of previously mentioned shared forms from the `.github` repo by adding issue forms that are more tailored to `website` issues. If a repo has its own `.github/ISSUE_TEMPLATE` directory with files in it then it will not inherit community templates, as noted in [community health file documentation](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file#about-default-community-health-files).