### PR TITLE
Add breadcrumb navigation for mobile

### DIFF
--- a/src/website/layouts/docs_page.html
+++ b/src/website/layouts/docs_page.html
@@ -73,16 +73,24 @@
                 </div>
               </div>
             </li>
-            {% if not section=='' %}
-              <li style="text-transform: capitalize; margin-right: 12px">
-                <a href="/docs/{{version}}/{{section}}" style="padding-left: 12px">
-                  {{ section }}
-                </a>
-              </li>
-            {% endif %}
-            {% if not (title=='index') %}
-              <li style="text-transform: capitalize" class="is-active"><a>{{ title }}</a></li>
-            {% endif %}
+            <div class="field">
+              <div class="control">
+                <div class="select">
+                  <select onchange="if (this.value) window.location.href=this.value" style="border: none;">
+                    {% for name, section in data.docs.toc[version] %}
+                      {% if not name=='' %}
+                        <option {% if ('/docs' + '/' + version + '/' + name) == '/' + path %}selected="selected"{% endif %} value="{{ '/docs' + '/' + version + '/' + name }}">{{ name }}</a>
+                      {% endif %}
+                      {% for item in data.docs.toc[version][name] %}
+                        {% if not (item.name == 'index') %}
+                            <option {% if item.link == '/' + path %}selected="selected"{% endif %} value="{{ item.link }}">{{ item.name }}</option>
+                        {% endif %}
+                      {% endfor %}
+                    {% endfor %}
+                  </select>
+                </div>
+              </div>
+            </div>
           </ul>
         </nav>
 


### PR DESCRIPTION
Right now, navigation in mobile is not possible as previous table of contents has been removed to simplify user flow. This PR adds the possibility of navigating in mobile devices without having to go back and forth from the toc.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
