### PR TITLE
Add support for multiple nesting relative links

### DIFF
--- a/src/scripts/processReleases.js
+++ b/src/scripts/processReleases.js
@@ -311,7 +311,15 @@ const extractPlugins = (pluginContent) => {
 }
 
 async function extractEcosystemFromFile (file) {
-  const data = await fs.readFile(file, 'utf8')
+  let data
+  try {
+    data = await fs.readFile(file, 'utf8')
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      const legacyEcosystemFile = file.replace('Guides', '')
+      data = await fs.readFile(legacyEcosystemFile, 'utf8')
+    }
+  }
 
   const content = data.toString()
   const corePluginsContent = content
@@ -335,7 +343,7 @@ async function createEcosystemDataFile (masterReleaseDownloadPath) {
   const destination = join(destFolder, 'data', 'ecosystem.yml')
   const files = await fs.readdir(versionFolder)
   const subfolder = files.find(file => file.match(/^fastify-/))
-  const ecosystemFile = join(versionFolder, subfolder, 'docs', 'Ecosystem.md')
+  const ecosystemFile = join(versionFolder, subfolder, 'docs', 'Guides', 'Ecosystem.md')
 
   const ecosystem = await extractEcosystemFromFile(ecosystemFile)
   await fs.writeFile(destination, dump(ecosystem), 'utf8')

--- a/src/scripts/processReleases.js
+++ b/src/scripts/processReleases.js
@@ -177,7 +177,7 @@ async function processDocFiles (docs, latestRelease) {
     // adds frontmatter
     content =
 `---
-title: ${item.name}
+title: ${item.name === 'index' ? item.section === '' ? 'Documentation' : item.section : item.name}
 layout: docs_page.html
 path: ${item.link}
 version: ${item.version}

--- a/src/scripts/processReleases.js
+++ b/src/scripts/processReleases.js
@@ -240,7 +240,7 @@ function remapLinks (content, item) {
   const docInternalLinkRx = /\(\/docs\/[\w\d.-]+\/[\w\d-]+(.md)/gi
   const ecosystemLink = /\(Ecosystem\.md\)/gi
   const pluginsLink = /\(Plugins.md\)/gi
-  const relativeLinks = /\((.\/)?(([a-zA-Z0-9\-_]+).md(#[a-z0-9\-_]+)?)\)/gi
+  const relativeLinks = /\((.\/)?(([/\w-]+).md(#[\w-]+)?)\)/gi
   const relativeLinksWithLabel = /\('?(\.\/)([\w\d.-]+)(.md)'?\s+"([\w\d.-]+)"\)/gi
   const hrefAbsoluteLinks = /href="https:\/\/github\.com\/fastify\/fastify\/blob\/master\/docs\/([\w\d.-]+)\.md/gi
   const absoluteLinks = /https:\/\/github.com\/fastify\/fastify\/blob\/master\/docs/gi
@@ -260,7 +260,11 @@ function remapLinks (content, item) {
     .replace(ecosystemLinkRx, (match) => '(/ecosystem)')
     .replace(ecosystemLink, (match) => '(/ecosystem)')
     .replace(pluginsLink, (match) => `(/docs/${item.version}${item.section !== '' ? '/' + item.section : ''}/Plugins)`)
-    .replace(relativeLinks, (match, ...parts) => `(/docs/${item.version}${item.section !== '' ? '/' + item.section : ''}/${parts[2]}${parts[3] || ''})`)
+    .replace(relativeLinks, (match, ...parts) => {
+      return `(/docs/${item.version}${item.section !== '' ? '/' + item.section : ''}/${parts[2]}${parts[3] || ''})`
+        // handle nested indexes to default to root
+        .replace(/index/ig, '')
+    })
     .replace(relativeLinksWithLabel, (match, ...parts) => `(/docs/${item.version}${item.section !== '' ? '/' + item.section : ''}/${parts[1]} "${parts[3]}")`)
     .replace(docInternalLinkRx, (match, p1) => match.replace(p1, ''))
     .replace(docResourcesLink, (match, p1) => `(/docs/${item.version}/resources/${p1})`)

--- a/src/website/layouts/ecosystem.html
+++ b/src/website/layouts/ecosystem.html
@@ -19,7 +19,7 @@
           <a href="#Community Plugins"><strong>{{ data.ecosystem.plugins.communityPlugins | length }}</strong> community plugins</a>
         </li>
         <li>A core plugin is a plugin maintained by the fastify team, and we make our best to maintain them according
-          to <a href="https://github.com/fastify/fastify/blob/master/docs/LTS.md">https://github.com/fastify/fastify/blob/master/docs/LTS.md.</a></li>
+          to <a href="https://github.com/fastify/fastify/blob/master/docs/Reference/LTS.md">https://github.com/fastify/fastify/blob/master/Reference/docs/LTS.md.</a></li>
         <li>We guarantee that every community plugin respects Fastify best practices (tests, etc) at the time they have
           been added to the list. We offer no guarantee on their maintenance.</li>
         <li>


### PR DESCRIPTION
fixes #305

Seems that the website was only supporting one level of nest for relative links. This is a quick fix. But my goal this week will be to add consistency to all this linking and remapping system.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
