### PR TITLE
Add default styling for searchbox

### DIFF
--- a/src/website/content/css/style.scss
+++ b/src/website/content/css/style.scss
@@ -291,3 +291,29 @@ a img, a svg {
 code, pre {
   font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
 }
+
+// Algolia SearchBar
+.DocSearch {
+  width: 100%;
+  
+  &.DocSearch-Button{
+    margin: 0 !important;
+    border: 1px solid black;
+    border-radius: 0;
+    background-color: transparent;
+  }
+
+  &-Button-Keys {
+    display: none !important;
+  }
+
+  &:hover {
+    box-shadow: none !important;
+  }
+
+  &-Search-Icon {
+    transform: scale(.66);
+    transform-origin: center;
+    margin-right: 5px;
+  }
+}


### PR DESCRIPTION
closes #310 

For this to be ready we need to see if there is a way in the config to change the placeholder to something like `Search... (ctrl + k)`

Desktop:
![image](https://user-images.githubusercontent.com/44276180/146058325-ff272f98-7727-4ce3-813a-2271131cd6e4.png)

Mobile:
![image](https://user-images.githubusercontent.com/44276180/146058363-93ddc1ac-ebe2-4475-94f7-7e6eb16c5a91.png)


#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
