### PR TITLE
Fix broken links

### DIFF
--- a/src/scripts/processReleases.js
+++ b/src/scripts/processReleases.js
@@ -277,10 +277,6 @@ function remapLinks (content, item) {
         .replace(p2, '')
     })
     .replace(docResourcesLink, (match, p1) => `(/docs/${item.version}/resources/${p1})`)
-    .replace(localAnchorLink, function (match, p1) {
-      const section = item.section !== '' ? item.section : ''
-      return `(/docs/${item.version}/${section}/${item.name}${p1})`
-    })
     .replace(localReferenceLink, function (match, p1, p2, p3) {
       const section = item.section !== '' ? item.section : ''
       return `${p1}(/docs/${item.version}${section}/${p2}${p3 ?? ''})`

--- a/src/scripts/processReleases.js
+++ b/src/scripts/processReleases.js
@@ -242,15 +242,14 @@ function remapLinks (content, item) {
   const docInternalLinkRx = /\(\/docs\/([\w\d.-]+)\/[\w\d-]+(.md)\)/gi
   const ecosystemLink = /\(Ecosystem\.md\)/gi
   const pluginsLink = /\(Plugins.md\)/gi
-  /* e.g. [foo](./foo/bar.md#baz) */
-  const relativeLinks = /\(([..?/]+)(([\w/-]+\/?).md\/?(#[\w-]+)?)\)/gi
-  const relativeLinksWithLabel = /\('?(\.\/)([\w\d.-]+)(.md)'?\s+"([\w\d.-]+)"\)/gi
   const hrefAbsoluteLinks = /href="https:\/\/github\.com\/fastify\/fastify\/blob\/master\/docs\/([\w\d.-]+)\.md/gi
   const absoluteLinks = /https:\/\/github.com\/fastify\/fastify\/blob\/master\/docs/gi
-  const docResourcesLink = /\(.\/?resources\/([a-zA-Z0-9\-_]+\..+)\)/gi
-
-  /* e.g. [foo](#bar) */
-  const localAnchorLink = /\((#[a-z0-9\-_]+)\)/gi
+  /* e.g. [foo](./foo/bar.md#baz) */
+  const relativeLinks = /\(([..?/]+)(([\w/-]+\/?).md\/?(#[\w-]+)?)\)/gi
+  /* e.g. [foo](./foo/bar.md#baz "Example Label") */
+  const relativeLinksWithLabel = /\('?(\.\/)([\w\d.-]+)(.md)'?\s+"([\w\d.-]+)"\)/gi
+  /* e.g. (../resources/encapsulation_context.svg) */
+  const docResourcesLink = /\(..?\/?resources\/([a-zA-Z0-9\-_]+\..+)\)/gi
   /* e.g. [foo]: ./foo/bar.md#baz */
   const localReferenceLink = /(\[[\w\s()]+\]:?)\s?([\w-./]+).md(#[\w]+)?/gi
 

--- a/src/scripts/processReleases.js
+++ b/src/scripts/processReleases.js
@@ -242,7 +242,7 @@ function remapLinks (content, item) {
   const docInternalLinkRx = /\(\/docs\/([\w\d.-]+)\/[\w\d-]+(.md)\)/gi
   const ecosystemLink = /\(Ecosystem\.md\)/gi
   const pluginsLink = /\(Plugins.md\)/gi
-  const relativeLinks = /\((.\/)?(([/\w-]+).md(#[\w-]+)?)\)/gi
+  const relativeLinks = /\((..?\/)((.*)\.[\w-]+(#[\w-]+)?)\)/gi
   const relativeLinksWithLabel = /\('?(\.\/)([\w\d.-]+)(.md)'?\s+"([\w\d.-]+)"\)/gi
   const hrefAbsoluteLinks = /href="https:\/\/github\.com\/fastify\/fastify\/blob\/master\/docs\/([\w\d.-]+)\.md/gi
   const absoluteLinks = /https:\/\/github.com\/fastify\/fastify\/blob\/master\/docs/gi

--- a/src/scripts/processReleases.js
+++ b/src/scripts/processReleases.js
@@ -243,7 +243,7 @@ function remapLinks (content, item) {
   const ecosystemLink = /\(Ecosystem\.md\)/gi
   const pluginsLink = /\(Plugins.md\)/gi
   /* e.g. [foo](./foo/bar.md#baz) */
-  const relativeLinks = /\(([..?/]+)(([\w/-]+\/?).md(#[\w-]+)?)\)/gi
+  const relativeLinks = /\(([..?/]+)(([\w/-]+\/?).md\/?(#[\w-]+)?)\)/gi
   const relativeLinksWithLabel = /\('?(\.\/)([\w\d.-]+)(.md)'?\s+"([\w\d.-]+)"\)/gi
   const hrefAbsoluteLinks = /href="https:\/\/github\.com\/fastify\/fastify\/blob\/master\/docs\/([\w\d.-]+)\.md/gi
   const absoluteLinks = /https:\/\/github.com\/fastify\/fastify\/blob\/master\/docs/gi

--- a/src/scripts/processReleases.js
+++ b/src/scripts/processReleases.js
@@ -273,7 +273,11 @@ function remapLinks (content, item) {
         .replace(/index/ig, '')
     })
     .replace(relativeLinksWithLabel, (match, ...parts) => `(/docs/${item.version}${item.section !== '' ? '/' + item.section : ''}/${parts[1]} "${parts[3]}")`)
-    .replace(docInternalLinkRx, (match, p1) => match.replace(p1, ''))
+    .replace(docInternalLinkRx, (match, p1, p2) => {
+      return match
+        .replace(p1, `${item.version}/${p1}`)
+        .replace(p2, '')
+    })
     .replace(docResourcesLink, (match, p1) => `(/docs/${item.version}/resources/${p1})`)
     .replace(localAnchorLink, function (match, p1) {
       const section = item.section !== '' ? item.section : ''

--- a/src/scripts/processReleases.js
+++ b/src/scripts/processReleases.js
@@ -239,7 +239,7 @@ function remapLinks (content, item) {
     [XXXX](./resources/YYYY.ZZZZ) -> [XXXX](/docs/[VERSION]/resources/YYYY.ZZZZ)
   */
   const ecosystemLinkRx = /\(\/docs\/[\w\d.-]+\/Ecosystem\.md\)/gi
-  const docInternalLinkRx = /\(\/docs\/[\w\d.-]+\/[\w\d-]+(.md)/gi
+  const docInternalLinkRx = /\(\/docs\/([\w\d.-]+)\/[\w\d-]+(.md)\)/gi
   const ecosystemLink = /\(Ecosystem\.md\)/gi
   const pluginsLink = /\(Plugins.md\)/gi
   const relativeLinks = /\((.\/)?(([/\w-]+).md(#[\w-]+)?)\)/gi

--- a/src/scripts/processReleases.js
+++ b/src/scripts/processReleases.js
@@ -268,7 +268,7 @@ function remapLinks (content, item) {
     .replace(ecosystemLink, (match) => '(/ecosystem)')
     .replace(pluginsLink, (match) => `(/docs/${item.version}${item.section !== '' ? '/' + item.section : ''}/Plugins)`)
     .replace(relativeLinks, (match, ...parts) => {
-      return `(/docs/${item.version}${item.section !== '' ? '/' + item.section : ''}/${parts[2]}${parts[3] || ''})`
+      return `(${parts[0]}${parts[2]}${parts[3] || ''})`
         // handle nested indexes to default to root
         .replace(/index/ig, '')
     })

--- a/src/scripts/processReleases.js
+++ b/src/scripts/processReleases.js
@@ -242,7 +242,8 @@ function remapLinks (content, item) {
   const docInternalLinkRx = /\(\/docs\/([\w\d.-]+)\/[\w\d-]+(.md)\)/gi
   const ecosystemLink = /\(Ecosystem\.md\)/gi
   const pluginsLink = /\(Plugins.md\)/gi
-  const relativeLinks = /\((..?\/)((.*)\.[\w-]+(#[\w-]+)?)\)/gi
+  /* e.g. [foo](./foo/bar.md#baz) */
+  const relativeLinks = /\(([..?/]+)(([\w/-]+\/?).md(#[\w-]+)?)\)/gi
   const relativeLinksWithLabel = /\('?(\.\/)([\w\d.-]+)(.md)'?\s+"([\w\d.-]+)"\)/gi
   const hrefAbsoluteLinks = /href="https:\/\/github\.com\/fastify\/fastify\/blob\/master\/docs\/([\w\d.-]+)\.md/gi
   const absoluteLinks = /https:\/\/github.com\/fastify\/fastify\/blob\/master\/docs/gi
@@ -250,8 +251,6 @@ function remapLinks (content, item) {
 
   /* e.g. [foo](#bar) */
   const localAnchorLink = /\((#[a-z0-9\-_]+)\)/gi
-  /* e.g. [foo](./foo/bar.md#baz) */
-  const relativeDocLink = /(\[[\w\s()]+\]:?)\s?\(([\w-./]+)\.md(#[\w]+)?\)/gi
   /* e.g. [foo]: ./foo/bar.md#baz */
   const localReferenceLink = /(\[[\w\s()]+\]:?)\s?([\w-./]+).md(#[\w]+)?/gi
 
@@ -268,7 +267,7 @@ function remapLinks (content, item) {
     .replace(ecosystemLink, (match) => '(/ecosystem)')
     .replace(pluginsLink, (match) => `(/docs/${item.version}${item.section !== '' ? '/' + item.section : ''}/Plugins)`)
     .replace(relativeLinks, (match, ...parts) => {
-      return `(../${parts[0]}${parts[2]}${parts[3] || ''})`
+      return `(${(item.name.toLowerCase() === 'index') ? '' : '../'}${parts[0]}${parts[2]}${parts[3] || ''})`
         // handle nested indexes to default to root
         .replace(/index/ig, '')
     })
@@ -282,10 +281,6 @@ function remapLinks (content, item) {
     .replace(localAnchorLink, function (match, p1) {
       const section = item.section !== '' ? item.section : ''
       return `(/docs/${item.version}/${section}/${item.name}${p1})`
-    })
-    .replace(relativeDocLink, function (match, p1, p2, p3) {
-      const section = item.section !== '' ? item.section : ''
-      return `${p1}(/docs/${item.version}${section}/${p2}${p3 ?? ''})`
     })
     .replace(localReferenceLink, function (match, p1, p2, p3) {
       const section = item.section !== '' ? item.section : ''

--- a/src/scripts/processReleases.js
+++ b/src/scripts/processReleases.js
@@ -268,7 +268,7 @@ function remapLinks (content, item) {
     .replace(ecosystemLink, (match) => '(/ecosystem)')
     .replace(pluginsLink, (match) => `(/docs/${item.version}${item.section !== '' ? '/' + item.section : ''}/Plugins)`)
     .replace(relativeLinks, (match, ...parts) => {
-      return `(${parts[0]}${parts[2]}${parts[3] || ''})`
+      return `(../${parts[0]}${parts[2]}${parts[3] || ''})`
         // handle nested indexes to default to root
         .replace(/index/ig, '')
     })

--- a/src/website/layouts/ecosystem.html
+++ b/src/website/layouts/ecosystem.html
@@ -23,7 +23,7 @@
         <li>We guarantee that every community plugin respects Fastify best practices (tests, etc) at the time they have
           been added to the list. We offer no guarantee on their maintenance.</li>
         <li>
-            Can't you find the plugin you are looking for? No problem, <a href="/docs/master/Plugins">it's very easy to
+            Can't you find the plugin you are looking for? No problem, <a href="/docs/master/Reference/Plugins">it's very easy to
               write one</a>!
         </li>
       </ul>

--- a/src/website/layouts/home.html
+++ b/src/website/layouts/home.html
@@ -350,7 +350,7 @@ start()</code></pre>
         <p>
           Fastify has an ever-growing ecosystem of plugins. Probably there is already a plugin for your favourite database or template language.
           Have a look at the <a href="/ecosystem">Ecosystem page</a> to navigate through the currently available plugins.
-          Can't you find the plugin you are looking for? No problem, <a href="/docs/master/Plugins">it's very easy to write one</a>!
+          Can't you find the plugin you are looking for? No problem, <a href="/docs/master/Reference/Plugins">it's very easy to write one</a>!
         </p>
         <div class="block">
 	  <!-- TAG: "Changed the statement to count plugins" -->


### PR DESCRIPTION
Due to some reports about broken links, I'm opening this PR to detect all the edge cases that were not covered by the previous website and fix current reports.

### Broken Links list:

- [x] [website](https://github.com/fastify/fastify/blob/627f7bde9a5d483f68b765668ea4fe964ab41cbf/docs/Reference/Encapsulation.md?plain=1#L8)
- [x] [website](https://github.com/fastify/fastify/blob/627f7bde9a5d483f68b765668ea4fe964ab41cbf/docs/Reference/Hooks.md?plain=1#L39)
- [x] Missing encapsulation `svg`
- [x] [website](https://github.com/fastify/fastify/blob/627f7bde9a5d483f68b765668ea4fe964ab41cbf/docs/Reference/Middleware.md?plain=1#L44)

- docs: needs to be fixed in fastify/fastify
- web: needs to be fixed in fastify/website

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)