### PR TITLE
Add Netlify badge to footer

### DIFF
--- a/src/website/layouts/partials/footer.html
+++ b/src/website/layouts/partials/footer.html
@@ -5,6 +5,9 @@
       <p><em>Found a typo or want to improve this page?</em> <a href="{{ github_url }}">Submit a PR on GitHub</a></p>
     {% endif %}
       <p>Fastify, Copyright &copy; 2016-{{ currentYear }} <a href="https://openjsf.org/" target="_blank" rel="noopener">OpenJS Foundation</a> and <a href="https://github.com/fastify/fastify#team" target="_blank" rel="noopener">The Fastify team</a>, Licensed under <a href="https://github.com/fastify/fastify/blob/master/LICENSE" target="_blank" rel="noopener">MIT</a></p>
+      <a href="https://www.netlify.com">
+        <img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" alt="Deploys by Netlify" />
+      </a>
       <p><small>Icons by simpleicons.org</small></p>
     </div>
   </div>


### PR DESCRIPTION
As seen in #315 , this PR adds the Netlify badge to start the migration process to the cited provider.

![image](https://user-images.githubusercontent.com/44276180/146812699-7fd699e6-c018-4cd6-b7c5-ff7d24821f16.png)


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
