### PR TITLE
chore: move microsoft to past sponsor

### DIFF
--- a/src/website/data/acknowledgements.yml
+++ b/src/website/data/acknowledgements.yml
@@ -1,11 +1,11 @@
 sponsors:
   - name: NearForm
     url: http://nearform.com
-  - name: Microsoft
-    url: https://opensource.microsoft.com/
 past_sponsors:
   - name: LetzDoIt
     url: http://www.letzdoitapp.com
+  - name: Microsoft
+    url: https://opensource.microsoft.com/
 others:
   - name: The amazing Fastify community
     url: https://github.com/fastify/fastify/graphs/contributors


### PR DESCRIPTION
Microsoft no longer sponsoring `fastify` project.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
