### PR TITLE
refactor: update examples to pass object to listen method

### DIFF
--- a/src/website/layouts/home.html
+++ b/src/website/layouts/home.html
@@ -116,7 +116,7 @@ fastify.get('/', (request, reply) => {
 })
 
 // Run the server!
-fastify.listen(3000, (err) => {
+fastify.listen({ port: 3000 }, (err) => {
   if (err) {
     fastify.log.error(err)
     process.exit(1)
@@ -133,7 +133,7 @@ fastify.get('/', async (request, reply) => {
 // Run the server!
 const start = async () => {
   try {
-    await fastify.listen(3000)
+    await fastify.listen({ port: 3000 })
   } catch (err) {
     fastify.log.error(err)
     process.exit(1)
@@ -200,7 +200,7 @@ fastify.route({
   }
 })
 
-fastify.listen(3000, (err) => {
+fastify.listen({ port: 3000 }, (err) => {
   if (err) {
     fastify.log.error(err)
     process.exit(1)
@@ -237,7 +237,7 @@ fastify.route({
 
 const start = async () => {
   try {
-    await fastify.listen(3000)
+    await fastify.listen({ port: 3000 })
   } catch (err) {
     fastify.log.error(err)
     process.exit(1)
@@ -286,7 +286,7 @@ server.get('/ping', opts, (request, reply) => {
   reply.send({ pong: 'it worked!' })
 })
 
-server.listen(3000, (err) => {
+server.listen({ port: 3000 }, (err) => {
   if (err) {
     server.log.error(err)
     process.exit(1)
@@ -322,7 +322,7 @@ server.get('/ping', opts, async (request, reply) => {
 
 const start = async () => {
   try {
-    await server.listen(3000)
+    await server.listen({ port: 3000 })
 
     const address = server.server.address()
     const port = typeof address === 'string' ? address : address?.port


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

The code examples on the home page are using a deprecated `listen` method. This updates the examples to pass the options object to the `listen` method.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
