### PR TITLE
Update `<meta name="theme-color" />`

### DIFF
--- a/src/website/layouts/partials/head.html
+++ b/src/website/layouts/partials/head.html
@@ -22,7 +22,7 @@
   <link rel="manifest" href="/manifest.json">
   <meta name="msapplication-TileColor" content="#ffffff">
   <meta name="msapplication-TileImage" content="/images/ms-icon-144x144.png">
-  <meta name="theme-color" content="#ffffff">
+  <meta name="theme-color" content="#202020">
 
   {% include 'partials/social-graph.html' %}
 


### PR DESCRIPTION
Updating  `<meta name="theme-color" />` for the docs. For more info https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color

I choosed `#202020` as a theme-color hence presents in `Fastify` website.

_Sorry if I made any mistakes :(_