### PR TITLE
Add Mastodon link

### DIFF
--- a/src/website/layouts/partials/header.html
+++ b/src/website/layouts/partials/header.html
@@ -38,6 +38,9 @@
       <a class="navbar-item" href="https://twitter.com/fastifyjs" target="_blank" rel="noopener">
         <span class="fa fa-twitter"> </span>&nbsp;Twitter
       </a>
+      <a class="navbar-item" rel="me" href="https://fosstodon.org/@fastify" target="_blank">Mastodon</a>
+        <span class="fa fa-hashtag"> </span>&nbsp;Mastodon
+      </a>
     </div>
   </div>
 </nav>

--- a/src/website/layouts/partials/header.html
+++ b/src/website/layouts/partials/header.html
@@ -38,7 +38,7 @@
       <a class="navbar-item" href="https://twitter.com/fastifyjs" target="_blank" rel="noopener">
         <span class="fa fa-twitter"> </span>&nbsp;Twitter
       </a>
-      <a class="navbar-item" rel="me" href="https://fosstodon.org/@fastify" target="_blank">Mastodon</a>
+      <a class="navbar-item" rel="me" href="https://fosstodon.org/@fastify" target="_blank">
         <span class="fa fa-hashtag"> </span>&nbsp;Mastodon
       </a>
     </div>


### PR DESCRIPTION
As titled.

Since the version we are using of font-awesome (4.7) does not have the mastodon logo, I've used a `#`, once we upgrade font-awesome to 6+, we can change it to the official logo.